### PR TITLE
Added camera resolutions into settings dialog

### DIFF
--- a/src/Detector.pro
+++ b/src/Detector.pro
@@ -39,7 +39,8 @@ SOURCES += main.cpp\
     uploader.cpp \
     settingsdialog.cpp \
     config.cpp \
-    detectionareaeditdialog.cpp
+    detectionareaeditdialog.cpp \
+    camerainfo.cpp
 
 HEADERS  += \
     recorder.h \
@@ -55,7 +56,8 @@ HEADERS  += \
     OpencvInclude.h \
     settingsdialog.h \
     config.h \
-    detectionareaeditdialog.h
+    detectionareaeditdialog.h \
+    camerainfo.h
 
 FORMS    += \
     mainwindow.ui \

--- a/src/Detector.pro
+++ b/src/Detector.pro
@@ -40,7 +40,8 @@ SOURCES += main.cpp\
     settingsdialog.cpp \
     config.cpp \
     detectionareaeditdialog.cpp \
-    camerainfo.cpp
+    camerainfo.cpp \
+    cameraresolutiondialog.cpp
 
 HEADERS  += \
     recorder.h \
@@ -57,7 +58,8 @@ HEADERS  += \
     settingsdialog.h \
     config.h \
     detectionareaeditdialog.h \
-    camerainfo.h
+    camerainfo.h \
+    cameraresolutiondialog.h
 
 FORMS    += \
     mainwindow.ui \
@@ -65,7 +67,8 @@ FORMS    += \
     imageexplorer.ui \
     uploader.ui \
     settingsdialog.ui \
-    detectionareaeditdialog.ui
+    detectionareaeditdialog.ui \
+    cameraresolutiondialog.ui
 
 windows {
     INCLUDEPATH += C:\own\install\include

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -26,27 +26,47 @@
  */
 Camera::Camera(int index, int width, int height)
 {
-    m_cameraInfo = new CameraInfo(index);
-    webcam.open(index);
-    webcam.set(CV_CAP_PROP_FRAME_WIDTH, width);
-    webcam.set(CV_CAP_PROP_FRAME_HEIGHT, height);
-    int actualWidth = webcam.get(CV_CAP_PROP_FRAME_WIDTH);
-    int actualHeight = webcam.get(CV_CAP_PROP_FRAME_HEIGHT);
+    m_index = index;
+    m_width = width;
+    m_height = height;
 
-    if ((actualWidth != width) || (actualHeight != height))
+    std::cout << "Constructed camera with index " << m_index <<  std::endl;
+}
+
+bool Camera::init()
+{
+    m_webcam = new cv::VideoCapture(m_index);
+    m_webcam->open(m_index);
+    m_webcam->set(CV_CAP_PROP_FRAME_WIDTH, m_width);
+    m_webcam->set(CV_CAP_PROP_FRAME_HEIGHT, m_height);
+    int actualWidth = m_webcam->get(CV_CAP_PROP_FRAME_WIDTH);
+    int actualHeight = m_webcam->get(CV_CAP_PROP_FRAME_HEIGHT);
+
+    if ((actualWidth != m_width) || (actualHeight != m_height))
     {
-        qDebug() << "Warning: requested web camera size" << width << "x" << height <<
+        qDebug() << "Warning: requested web camera size" << m_width << "x" << m_height <<
                     "but got" << actualWidth << "x" << actualHeight;
     }
 
-    if(webcam.isOpened())
-	{
-        webcam.read(frameToReturn);
+    if(m_webcam->isOpened())
+    {
+        m_webcam->read(frameToReturn);
         isReadingWebcam=true;
         threadReadFrame.reset(new std::thread(&Camera::readWebcamFrame, this));
+    } else {
+        return false;
     }
+    return true;
+}
 
-    std::cout << "Constructed camera with index " << index <<  std::endl;
+void Camera::release()
+{
+    if (!m_webcam)
+    {
+        return;
+    }
+    stopReadingWebcam();
+    m_webcam->release();
 }
 
 /*
@@ -54,8 +74,7 @@ Camera::Camera(int index, int width, int height)
  */
 cv::Mat Camera::getWebcamFrame()
 {
-
-    if (videoFrame.data && videoFrame.isContinuous())
+    if (m_webcam && videoFrame.data && videoFrame.isContinuous())
 	{
         mutex.lock();
         frameToReturn = videoFrame.clone();
@@ -87,10 +106,10 @@ void Camera::stopReadingWebcam()
 void Camera::readWebcamFrame()
 {
     int yieldPauseUsec = 1000;    // e.g. at 25 FPS time between frames is 40,000 us
-    while(isReadingWebcam)
+    while(m_webcam && isReadingWebcam && isWebcamOpen())
     {
         mutex.lock();
-        webcam.read(videoFrame);
+        m_webcam->read(videoFrame);
         mutex.unlock();
         // give other threads better possibility to run
         std::this_thread::yield();
@@ -103,9 +122,14 @@ void Camera::readWebcamFrame()
  */
 bool Camera::isWebcamOpen()
 {
-    return webcam.isOpened();
+    if (!m_webcam)
+    {
+        return false;
+    }
+    return m_webcam->isOpened();
 }
 
-QList<QSize> Camera::availableResolutions() {
-    return m_cameraInfo->availableResolutions();
+int Camera::index()
+{
+    return m_index;
 }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -26,6 +26,7 @@
  */
 Camera::Camera(int index, int width, int height)
 {
+    m_cameraInfo = new CameraInfo(index);
     webcam.open(index);
     webcam.set(CV_CAP_PROP_FRAME_WIDTH, width);
     webcam.set(CV_CAP_PROP_FRAME_HEIGHT, height);
@@ -105,3 +106,6 @@ bool Camera::isWebcamOpen()
     return webcam.isOpened();
 }
 
+QList<QSize> Camera::availableResolutions() {
+    return m_cameraInfo->availableResolutions();
+}

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -26,6 +26,7 @@ Camera::Camera(int index, int width, int height)
     m_index = index;
     m_width = width;
     m_height = height;
+    m_initialized = false;
 
     m_cameraInfo = new CameraInfo(m_index);
     connect(m_cameraInfo, SIGNAL(queryProgressChanged(int)), this, SIGNAL(queryProgressChanged(int)));
@@ -56,7 +57,13 @@ bool Camera::init()
     } else {
         return false;
     }
+    m_initialized = true;
     return true;
+}
+
+bool Camera::isInitialized()
+{
+    return m_initialized;
 }
 
 void Camera::release()
@@ -67,6 +74,7 @@ void Camera::release()
     }
     stopReadingWebcam();
     m_webcam->release();
+    m_initialized = false;
 }
 
 /*

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -21,14 +21,14 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <QDebug>
 
-/*
- * Main Camera class to handle reading of frames from multiple threads
- */
 Camera::Camera(int index, int width, int height)
 {
     m_index = index;
     m_width = width;
     m_height = height;
+
+    m_cameraInfo = new CameraInfo(m_index);
+    connect(m_cameraInfo, SIGNAL(queryProgressChanged(int)), this, SIGNAL(queryProgressChanged(int)));
 
     std::cout << "Constructed camera with index " << m_index <<  std::endl;
 }
@@ -132,4 +132,28 @@ bool Camera::isWebcamOpen()
 int Camera::index()
 {
     return m_index;
+}
+
+bool Camera::queryAvailableResolutions()
+{
+    if (!m_cameraInfo->isInitialized())
+    {
+        // first release current cv::VideoCapture & stop frame grab thread
+        this->release();
+        // CameraInfo::init() will reserve cv::VideoCapture and do the query
+        m_cameraInfo->init();
+        // now can continue using own cv::VideoCapture and restart frame grab thread
+        this->init();
+    }
+    return true;
+}
+
+QList<QSize> Camera::availableResolutions()
+{
+    return m_cameraInfo->availableResolutions();
+}
+
+QList<int> Camera::knownAspectRatios()
+{
+    return m_cameraInfo->knownAspectRatios();
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -30,25 +30,51 @@
 class Camera
 {
 public:
+    /**
+     * @brief Camera create camera. You need to call Camera::init() to actually start using the camera.
+     * @param index camera index as used by OpenCV
+     * @param width camera frame width
+     * @param height camera frame height
+     * Note that given resolution (width * height) may not be supported, but normally
+     * you will get nearest supported resolution anyway.
+     */
     Camera(int index, int width, int height);
+
+    /**
+     * @brief init initialize and open camera
+     * @return true if initialization was successful, false if it failed
+     */
+    bool init();
+
+    /**
+     * @brief release stop and close camera
+     */
+    void release();
+
+    /**
+     * @brief getWebcamFrame get the current/newest frame from camera
+     * @return
+     */
     cv::Mat getWebcamFrame();
     void stopReadingWebcam();
     bool isWebcamOpen();
 
     /**
-     * @brief availableResolutions get list of available resolutions
-     * The list is sorted in ascending order.
+     * @brief index camera index
+     * @return
      */
-    QList<QSize> availableResolutions();
+    int index();
 
 private:
+    int m_index;    ///< camera index as used by OpenCV
+    int m_width;
+    int m_height;
     std::atomic<bool> isReadingWebcam;
-    cv::VideoCapture webcam;
-    CameraInfo* m_cameraInfo;   ///< camera info to get available resolutions
+    cv::VideoCapture* m_webcam;
     cv::Mat videoFrame;
     cv::Mat frameToReturn;
     std::mutex mutex;
-    void readWebcamFrame();
+    void readWebcamFrame();     ///< thread method for continuous reading of frames
     std::unique_ptr<std::thread> threadReadFrame;
 };
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -25,10 +25,17 @@
 #include <thread>
 #include <atomic>
 #include <memory>
+#include <QObject>
 
-
-class Camera
+/**
+ * @brief Main Camera class to handle reading of frames from multiple threads
+ *
+ * @todo add setResolution(width, height) method to apply resolution change on-the-fly
+ */
+class Camera : public QObject
 {
+    Q_OBJECT
+
 public:
     /**
      * @brief Camera create camera. You need to call Camera::init() to actually start using the camera.
@@ -65,7 +72,27 @@ public:
      */
     int index();
 
+    /**
+     * @brief queryAvailableResolutions run web camera resolution query
+     * @return
+     */
+    bool queryAvailableResolutions();
+
+    /**
+     * @brief availableResolutions list of available web camera resolutions
+     * @return list of resolutions, or an empty list if queryAvailableResolutions() was not called previously
+     */
+    QList<QSize> availableResolutions();
+
+    /**
+     * @brief knownAspectRatios list of known aspect ratios. List may grow on queryAvailableResolutions().
+     * @return
+     */
+    QList<int> knownAspectRatios();
+
+#ifndef _UNIT_TEST_
 private:
+#endif
     int m_index;    ///< camera index as used by OpenCV
     int m_width;
     int m_height;
@@ -76,6 +103,15 @@ private:
     std::mutex mutex;
     void readWebcamFrame();     ///< thread method for continuous reading of frames
     std::unique_ptr<std::thread> threadReadFrame;
+    CameraInfo* m_cameraInfo;
+
+signals:
+    /**
+     * @brief queryProgressChanged emitted when querying available resolutions progresses
+     * @param percent percent of querying ready
+     */
+    void queryProgressChanged(int percent);
+
 };
 
 #endif // CAMERA_H

--- a/src/camera.h
+++ b/src/camera.h
@@ -54,6 +54,12 @@ public:
     bool init();
 
     /**
+     * @brief isInitialized whether the camera is initialized
+     * @return true if camera is initialized, false if not
+     */
+    bool isInitialized();
+
+    /**
      * @brief release stop and close camera
      */
     void release();
@@ -104,6 +110,7 @@ private:
     void readWebcamFrame();     ///< thread method for continuous reading of frames
     std::unique_ptr<std::thread> threadReadFrame;
     CameraInfo* m_cameraInfo;
+    bool m_initialized;     ///< whether camera is initialized or not
 
 signals:
     /**

--- a/src/camera.h
+++ b/src/camera.h
@@ -18,6 +18,8 @@
 
 #ifndef CAMERA_H
 #define CAMERA_H
+
+#include "camerainfo.h"
 #include <opencv2/highgui/highgui.hpp>
 #include <mutex>
 #include <thread>
@@ -33,9 +35,16 @@ public:
     void stopReadingWebcam();
     bool isWebcamOpen();
 
+    /**
+     * @brief availableResolutions get list of available resolutions
+     * The list is sorted in ascending order.
+     */
+    QList<QSize> availableResolutions();
+
 private:
     std::atomic<bool> isReadingWebcam;
     cv::VideoCapture webcam;
+    CameraInfo* m_cameraInfo;   ///< camera info to get available resolutions
     cv::Mat videoFrame;
     cv::Mat frameToReturn;
     std::mutex mutex;

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -1,0 +1,84 @@
+#include "camerainfo.h"
+
+CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
+{
+    m_cameraIndex = cameraIndex;
+    /// @todo add common resolutions from https://en.wikipedia.org/wiki/List_of_common_resolutions
+    m_commonResolutions << QSize(16, 16);
+    m_commonResolutions << QSize(160, 120);
+    m_commonResolutions << QSize(320, 200);
+    m_commonResolutions << QSize(320, 240);
+    m_commonResolutions << QSize(352, 288);
+    m_commonResolutions << QSize(640, 480);
+    m_commonResolutions << QSize(800, 600);
+    m_commonResolutions << QSize(1024, 768);
+}
+
+QList<QSize> CameraInfo::availableResolutions() {
+    queryResolutions();
+    return m_availableResolutions;
+}
+
+bool CameraInfo::queryResolutions() {
+    int width = 0;
+    int height = 0;
+    QSize testRes;
+    QSize smallestResolution;
+    QSize largestResolution;
+    int smallestIndex;
+    int largestIndex;
+    if (!m_webCamera.open(m_cameraIndex)) {
+        qDebug() << "Couldn't connect to web camera" << m_cameraIndex;
+        return false;
+    }
+
+    qDebug() << "Querying web camera for supported resolutions";
+
+    // find smallest supported resolution
+    testRes = m_commonResolutions.at(0);
+    m_webCamera.set(CV_CAP_PROP_FRAME_WIDTH, testRes.width());
+    m_webCamera.set(CV_CAP_PROP_FRAME_HEIGHT, testRes.height());
+    width = m_webCamera.get(CV_CAP_PROP_FRAME_WIDTH);
+    height = m_webCamera.get(CV_CAP_PROP_FRAME_HEIGHT);
+    smallestResolution.setWidth(width);
+    smallestResolution.setHeight(height);
+    smallestIndex = m_commonResolutions.indexOf(smallestResolution);
+    if (smallestIndex < 0) {
+        /// @todo find out the nearest index at lower side if resolution not in list
+        smallestIndex = 0;
+    }
+    qDebug() << "Smallest resolution is" << width << "x" << height << "at index" << smallestIndex;
+
+    // find largest supported resolution
+    // Actually this test can be done in query loop below: just wait until size is larger than the last found
+    testRes = m_commonResolutions.at(m_commonResolutions.size() - 1);
+    m_webCamera.set(CV_CAP_PROP_FRAME_WIDTH, testRes.width());
+    m_webCamera.set(CV_CAP_PROP_FRAME_HEIGHT, testRes.height());
+    width = m_webCamera.get(CV_CAP_PROP_FRAME_WIDTH);
+    height = m_webCamera.get(CV_CAP_PROP_FRAME_HEIGHT);
+    largestResolution.setWidth(width);
+    largestResolution.setHeight(height);
+    largestIndex = m_commonResolutions.indexOf(largestResolution);
+    if (largestIndex < 0) {
+        /// @todo find out the nearest index at higher side if resolution not in list
+        largestIndex = m_commonResolutions.size() - 1;
+    }
+    qDebug() << "Largest resolution is" << width << "x" << height << "at index" << largestIndex;
+
+    for (int i = smallestIndex; i < (largestIndex + 1); i++) {
+        testRes = m_commonResolutions.at(i);
+        m_webCamera.set(CV_CAP_PROP_FRAME_WIDTH, testRes.width());
+        m_webCamera.set(CV_CAP_PROP_FRAME_HEIGHT, testRes.height());
+        width = m_webCamera.get(CV_CAP_PROP_FRAME_WIDTH);
+        height = m_webCamera.get(CV_CAP_PROP_FRAME_HEIGHT);
+        /// @todo if resolution is found which is not in common resolutions, add it to the available resolutions
+        if ((testRes.width() == width) && (testRes.height() == height)) {
+            qDebug() << testRes.width() << "x" << testRes.height() << "is supported";
+            m_availableResolutions << testRes;
+        } else {
+            qDebug() << testRes.width() << "x" << testRes.height() << "is not supported";
+        }
+    }
+    return true;
+}
+

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -199,6 +199,9 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QO
     m_commonResolutions << QSize(1600, 900);	// 900p
     m_commonResolutions << QSize(1920, 1080);	// HD 1080, 1080i, 1080p
 #endif
+
+    m_initialized = false;
+    updateAspectRatios();
 }
 
 bool CameraInfo::init() {
@@ -214,11 +217,20 @@ bool CameraInfo::init() {
         qDebug() << "Problem creating and opening web camera" << m_cameraIndex;
     }
     updateAspectRatios();
+    m_initialized = ok;
     return ok;
+}
+
+bool CameraInfo::isInitialized() {
+    return m_initialized;
 }
 
 QList<QSize> CameraInfo::availableResolutions() {
     return m_availableResolutions;
+}
+
+QList<int> CameraInfo::knownAspectRatios() {
+    return m_knownAspectRatios;
 }
 
 bool CameraInfo::queryResolutions() {
@@ -299,19 +311,20 @@ void CameraInfo::updateAspectRatios() {
     while (resIt.hasNext()) {
         res = resIt.next();
         aspectRatio = (double)res.width() / (double)res.height() * 10000;
-        if (!m_aspectRatios.contains(aspectRatio)) {
-            m_aspectRatios << aspectRatio;
+        if (!m_knownAspectRatios.contains(aspectRatio)) {
+            m_knownAspectRatios << aspectRatio;
         }
     }
 
     while (availableResIt.hasNext()) {
         res = availableResIt.next();
         aspectRatio = (double)res.width() / (double)res.height() * 10000;
-        if (!m_aspectRatios.contains(aspectRatio)) {
-            m_aspectRatios << aspectRatio;
+        if (!m_knownAspectRatios.contains(aspectRatio)) {
+            m_knownAspectRatios << aspectRatio;
         }
     }
-    std::sort(m_aspectRatios.begin(), m_aspectRatios.end(), std::less<int>());
+    // sort aspect ratios in ascending order
+    std::sort(m_knownAspectRatios.begin(), m_knownAspectRatios.end(), std::less<int>());
 }
 
 // static

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -151,6 +151,7 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QO
     m_commonResolutions << QSize(2048, 1536);
     m_commonResolutions << QSize(2048, 1556);
     m_commonResolutions << QSize(2160, 1440);
+    m_commonResolutions << QSize(2304, 1296);   // e.g. Logitech c920 undocumented resolution
     m_commonResolutions << QSize(2304, 1440);
     m_commonResolutions << QSize(2304, 1728);
     m_commonResolutions << QSize(2538, 1080);
@@ -212,6 +213,7 @@ bool CameraInfo::init() {
     } else {
         qDebug() << "Problem creating and opening web camera" << m_cameraIndex;
     }
+    updateAspectRatios();
     return ok;
 }
 
@@ -286,6 +288,30 @@ bool CameraInfo::queryResolutions() {
     emit queryProgressChanged(100);
 
     return true;
+}
+
+void CameraInfo::updateAspectRatios() {
+    int aspectRatio = 0;
+    QSize res(0, 0);
+    QListIterator<QSize> resIt(m_commonResolutions);
+    QListIterator<QSize> availableResIt(m_availableResolutions);
+
+    while (resIt.hasNext()) {
+        res = resIt.next();
+        aspectRatio = (double)res.width() / (double)res.height() * 10000;
+        if (!m_aspectRatios.contains(aspectRatio)) {
+            m_aspectRatios << aspectRatio;
+        }
+    }
+
+    while (availableResIt.hasNext()) {
+        res = availableResIt.next();
+        aspectRatio = (double)res.width() / (double)res.height() * 10000;
+        if (!m_aspectRatios.contains(aspectRatio)) {
+            m_aspectRatios << aspectRatio;
+        }
+    }
+    std::sort(m_aspectRatios.begin(), m_aspectRatios.end(), std::less<int>());
 }
 
 // static

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -6,6 +6,8 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
 
     // Source: https://en.wikipedia.org/wiki/List_of_common_resolutions (referenced 2016-05-02)
     // Used sections Common display formats, Video conferencing standards, Post-production
+
+#ifndef Q_OS_WINDOWS
     m_commonResolutions << QSize(32, 32);
     m_commonResolutions << QSize(40, 30);
     m_commonResolutions << QSize(42, 11);
@@ -183,6 +185,18 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
     m_commonResolutions << QSize(7680, 4320);	// 4320p
     m_commonResolutions << QSize(8192, 4608);
     m_commonResolutions << QSize(8192, 8192);
+#else
+    m_commonResolutions << QSize(320, 240);	// QVGA
+    m_commonResolutions << QSize(352, 288);	// CIF
+    m_commonResolutions << QSize(640, 480);	// VGA
+    m_commonResolutions << QSize(704, 576);	// 4CIF
+    m_commonResolutions << QSize(800, 600);	// SVGA
+    m_commonResolutions << QSize(1024, 768);	// XGA
+    m_commonResolutions << QSize(1280, 720);	// 720p
+    m_commonResolutions << QSize(1408, 1152);	// 16CIF
+    m_commonResolutions << QSize(1600, 900);	// 900p
+    m_commonResolutions << QSize(1920, 1080);	// HD 1080, 1080i, 1080p
+#endif
 
     m_webCamera = new cv::VideoCapture(m_cameraIndex);
     if (m_webCamera && m_webCamera->open(m_cameraIndex)) {
@@ -249,6 +263,7 @@ bool CameraInfo::queryResolutions() {
             qDebug() << "Web camera supports resolution" << width << "x" << height;
             m_availableResolutions << testRes;
         } else {
+            qDebug() << "No support for resolution" << testRes.width() << "x" << testRes.height() <<"-- got " << width << "x" << height << "instead";
             QSize newRes(width, height);
             if (!m_commonResolutions.contains(newRes) && !m_availableResolutions.contains(newRes)) {
                 m_availableResolutions << newRes;

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -3,15 +3,186 @@
 CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
 {
     m_cameraIndex = cameraIndex;
-    /// @todo add common resolutions from https://en.wikipedia.org/wiki/List_of_common_resolutions
-    m_commonResolutions << QSize(16, 16);
-    m_commonResolutions << QSize(160, 120);
+
+    // Source: https://en.wikipedia.org/wiki/List_of_common_resolutions (referenced 2016-05-02)
+    // Used sections Common display formats, Video conferencing standards, Post-production
+    m_commonResolutions << QSize(32, 32);
+    m_commonResolutions << QSize(40, 30);
+    m_commonResolutions << QSize(42, 11);
+    m_commonResolutions << QSize(42, 32);
+    m_commonResolutions << QSize(48, 32);
+    m_commonResolutions << QSize(60, 40);
+    m_commonResolutions << QSize(64, 64);
+    m_commonResolutions << QSize(72, 64);
+    m_commonResolutions << QSize(75, 64);
+    m_commonResolutions << QSize(84, 48);
+    m_commonResolutions << QSize(96, 64);
+    m_commonResolutions << QSize(96, 65);
+    m_commonResolutions << QSize(96, 96);
+    m_commonResolutions << QSize(102, 64);
+    m_commonResolutions << QSize(128, 36);
+    m_commonResolutions << QSize(128, 48);
+    m_commonResolutions << QSize(128, 96);
+    m_commonResolutions << QSize(128, 128);
+    m_commonResolutions << QSize(140, 192);
+    m_commonResolutions << QSize(144, 168);
+    m_commonResolutions << QSize(150, 40);
+    m_commonResolutions << QSize(160, 102);
+    m_commonResolutions << QSize(160, 120);	// QQVGA
+    m_commonResolutions << QSize(160, 144);
+    m_commonResolutions << QSize(160, 152);
+    m_commonResolutions << QSize(160, 160);
+    m_commonResolutions << QSize(160, 200);
+    m_commonResolutions << QSize(160, 256);
+    m_commonResolutions << QSize(176, 144);
+    m_commonResolutions << QSize(208, 176);
+    m_commonResolutions << QSize(208, 208);
+    m_commonResolutions << QSize(220, 176);
+    m_commonResolutions << QSize(224, 144);
+    m_commonResolutions << QSize(240, 64);
+    m_commonResolutions << QSize(240, 160);
+    m_commonResolutions << QSize(240, 240);
+    m_commonResolutions << QSize(256, 192);
+    m_commonResolutions << QSize(256, 256);
+    m_commonResolutions << QSize(272, 340);
+    m_commonResolutions << QSize(280, 192);
+    m_commonResolutions << QSize(312, 390);
+    m_commonResolutions << QSize(320, 192);
     m_commonResolutions << QSize(320, 200);
-    m_commonResolutions << QSize(320, 240);
-    m_commonResolutions << QSize(352, 288);
-    m_commonResolutions << QSize(640, 480);
-    m_commonResolutions << QSize(800, 600);
-    m_commonResolutions << QSize(1024, 768);
+    m_commonResolutions << QSize(320, 208);
+    m_commonResolutions << QSize(320, 224);
+    m_commonResolutions << QSize(320, 240);	// QVGA
+    m_commonResolutions << QSize(320, 256);
+    m_commonResolutions << QSize(320, 320);
+    m_commonResolutions << QSize(352, 288);	// CIF
+    m_commonResolutions << QSize(376, 240);
+    m_commonResolutions << QSize(384, 288);	// CIF
+    m_commonResolutions << QSize(400, 240);	// WQVGA
+    m_commonResolutions << QSize(400, 270);
+    m_commonResolutions << QSize(400, 300);
+    m_commonResolutions << QSize(416, 352);
+    m_commonResolutions << QSize(432, 128);
+    m_commonResolutions << QSize(432, 240);	// WQVGA
+    m_commonResolutions << QSize(480, 234);	// WQVGA
+    m_commonResolutions << QSize(480, 250);
+    m_commonResolutions << QSize(480, 272);
+    m_commonResolutions << QSize(480, 320);	// HVGA
+    m_commonResolutions << QSize(480, 500);
+    m_commonResolutions << QSize(512, 256);
+    m_commonResolutions << QSize(512, 342);
+    m_commonResolutions << QSize(512, 384);
+    m_commonResolutions << QSize(560, 192);
+    m_commonResolutions << QSize(600, 480);
+    m_commonResolutions << QSize(640, 200);
+    m_commonResolutions << QSize(640, 240);
+    m_commonResolutions << QSize(640, 256);	// HVGA
+    m_commonResolutions << QSize(640, 320);
+    m_commonResolutions << QSize(640, 350);	// EGA
+    m_commonResolutions << QSize(640, 360);
+    m_commonResolutions << QSize(640, 400);
+    m_commonResolutions << QSize(640, 480);	// VGA
+    m_commonResolutions << QSize(640, 512);
+    m_commonResolutions << QSize(704, 576);	// 4CIF
+    m_commonResolutions << QSize(720, 348);
+    m_commonResolutions << QSize(720, 350);
+    m_commonResolutions << QSize(720, 364);
+    m_commonResolutions << QSize(720, 480);	// DV NTSC
+    m_commonResolutions << QSize(720, 486);	// D1 NTSC
+    m_commonResolutions << QSize(720, 576);	// DV PAL
+    m_commonResolutions << QSize(720, 576);	// D1 PAL
+    m_commonResolutions << QSize(768, 480);	// WVGA
+    m_commonResolutions << QSize(800, 240);
+    m_commonResolutions << QSize(800, 352);
+    m_commonResolutions << QSize(800, 480);	// WGA
+    m_commonResolutions << QSize(800, 600);	// SVGA
+    m_commonResolutions << QSize(832, 624);
+    m_commonResolutions << QSize(848, 480);
+    m_commonResolutions << QSize(854, 480);	// FWVGA
+    m_commonResolutions << QSize(960, 540);
+    m_commonResolutions << QSize(960, 544);
+    m_commonResolutions << QSize(960, 640);
+    m_commonResolutions << QSize(960, 720);
+    m_commonResolutions << QSize(1024, 567);	// PAL 16:9
+    m_commonResolutions << QSize(1024, 600);	// WSVGA
+    m_commonResolutions << QSize(1024, 640);
+    m_commonResolutions << QSize(1024, 768);	// XGA
+    m_commonResolutions << QSize(1024, 800);
+    m_commonResolutions << QSize(1024, 1024);
+    m_commonResolutions << QSize(1120, 832);
+    m_commonResolutions << QSize(1136, 640);
+    m_commonResolutions << QSize(1152, 720);
+    m_commonResolutions << QSize(1152, 768);
+    m_commonResolutions << QSize(1152, 864);
+    m_commonResolutions << QSize(1152, 900);
+    m_commonResolutions << QSize(1280, 720);	// 720p
+    m_commonResolutions << QSize(1280, 768);
+    m_commonResolutions << QSize(1280, 800);
+    m_commonResolutions << QSize(1280, 854);
+    m_commonResolutions << QSize(1280, 960);
+    m_commonResolutions << QSize(1280, 1024);
+    m_commonResolutions << QSize(1280, 1080);
+    m_commonResolutions << QSize(1334, 740);
+    m_commonResolutions << QSize(1366, 768);	// HDTV 720p/1080i
+    m_commonResolutions << QSize(1400, 1050);
+    m_commonResolutions << QSize(1408, 1152);	// 16CIF
+    m_commonResolutions << QSize(1440, 900);
+    m_commonResolutions << QSize(1440, 960);
+    m_commonResolutions << QSize(1440, 1024);
+    m_commonResolutions << QSize(1440, 1080);
+    m_commonResolutions << QSize(1600, 768);
+    m_commonResolutions << QSize(1600, 900);	// 900p
+    m_commonResolutions << QSize(1600, 1024);
+    m_commonResolutions << QSize(1600, 1200);	// UXGA
+    m_commonResolutions << QSize(1600, 1280);
+    m_commonResolutions << QSize(1680, 1050);	// WSXGA+
+    m_commonResolutions << QSize(1792, 1344);
+    m_commonResolutions << QSize(1800, 1440);
+    m_commonResolutions << QSize(1856, 1392);
+    m_commonResolutions << QSize(1920, 1080);	// HD 1080, 1080i, 1080p
+    m_commonResolutions << QSize(1920, 1200);
+    m_commonResolutions << QSize(1920, 1280);
+    m_commonResolutions << QSize(1920, 1400);
+    m_commonResolutions << QSize(1920, 1440);
+    m_commonResolutions << QSize(2048, 1152);
+    m_commonResolutions << QSize(2048, 1280);
+    m_commonResolutions << QSize(2048, 1536);
+    m_commonResolutions << QSize(2048, 1556);
+    m_commonResolutions << QSize(2160, 1440);
+    m_commonResolutions << QSize(2304, 1440);
+    m_commonResolutions << QSize(2304, 1728);
+    m_commonResolutions << QSize(2538, 1080);
+    m_commonResolutions << QSize(2560, 1080);
+    m_commonResolutions << QSize(2560, 1440);
+    m_commonResolutions << QSize(2560, 1600);
+    m_commonResolutions << QSize(2560, 1700);
+    m_commonResolutions << QSize(2560, 1800);
+    m_commonResolutions << QSize(2560, 1920);
+    m_commonResolutions << QSize(2560, 2048);
+    m_commonResolutions << QSize(2732, 2048);
+    m_commonResolutions << QSize(2736, 1824);
+    m_commonResolutions << QSize(2800, 2100);
+    m_commonResolutions << QSize(2880, 900);
+    m_commonResolutions << QSize(2880, 1800);
+    m_commonResolutions << QSize(3000, 2000);
+    m_commonResolutions << QSize(3200, 1800);
+    m_commonResolutions << QSize(3200, 2048);
+    m_commonResolutions << QSize(3200, 2400);
+    m_commonResolutions << QSize(3440, 1440);
+    m_commonResolutions << QSize(3656, 2664);
+    m_commonResolutions << QSize(3840, 2160);
+    m_commonResolutions << QSize(3840, 2400);
+    m_commonResolutions << QSize(4096, 2304);
+    m_commonResolutions << QSize(4096, 3072);
+    m_commonResolutions << QSize(4096, 3112);
+    m_commonResolutions << QSize(5120, 2160);
+    m_commonResolutions << QSize(5120, 2880);
+    m_commonResolutions << QSize(5120, 3200);	// WHXGA
+    m_commonResolutions << QSize(5120, 4096);
+    m_commonResolutions << QSize(6400, 4096);
+    m_commonResolutions << QSize(6400, 4800);
+    m_commonResolutions << QSize(7680, 4320);	// 4320p
+    m_commonResolutions << QSize(8192, 4608);
+    m_commonResolutions << QSize(8192, 8192);
 }
 
 QList<QSize> CameraInfo::availableResolutions() {
@@ -47,7 +218,7 @@ bool CameraInfo::queryResolutions() {
         /// @todo find out the nearest index at lower side if resolution not in list
         smallestIndex = 0;
     }
-    qDebug() << "Smallest resolution is" << width << "x" << height << "at index" << smallestIndex;
+    qDebug() << "Smallest supported resolution is" << width << "x" << height;
 
     // find largest supported resolution
     // Actually this test can be done in query loop below: just wait until size is larger than the last found
@@ -63,7 +234,7 @@ bool CameraInfo::queryResolutions() {
         /// @todo find out the nearest index at higher side if resolution not in list
         largestIndex = m_commonResolutions.size() - 1;
     }
-    qDebug() << "Largest resolution is" << width << "x" << height << "at index" << largestIndex;
+    qDebug() << "Largest supported resolution is" << width << "x" << height;
 
     for (int i = smallestIndex; i < (largestIndex + 1); i++) {
         testRes = m_commonResolutions.at(i);
@@ -71,14 +242,31 @@ bool CameraInfo::queryResolutions() {
         m_webCamera.set(CV_CAP_PROP_FRAME_HEIGHT, testRes.height());
         width = m_webCamera.get(CV_CAP_PROP_FRAME_WIDTH);
         height = m_webCamera.get(CV_CAP_PROP_FRAME_HEIGHT);
-        /// @todo if resolution is found which is not in common resolutions, add it to the available resolutions
         if ((testRes.width() == width) && (testRes.height() == height)) {
-            qDebug() << testRes.width() << "x" << testRes.height() << "is supported";
             m_availableResolutions << testRes;
         } else {
-            qDebug() << testRes.width() << "x" << testRes.height() << "is not supported";
+            QSize newRes(width, height);
+            if (!m_commonResolutions.contains(newRes) && !m_availableResolutions.contains(newRes)) {
+                m_availableResolutions << newRes;
+            }
         }
     }
+
+    // finally sort the available resolutions first by width, then by height
+    std::sort(m_availableResolutions.begin(), m_availableResolutions.end(), CameraInfo::compareResolutionsWidthFirst);
+
     return true;
 }
 
+// static
+bool CameraInfo::compareResolutionsWidthFirst(QSize res1, QSize res2) {
+    if (res1.width() < res2.width()) {
+        return true;
+    }
+    if (res1.width() == res2.width()) {
+        if (res1.height() < res2.height()) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -1,6 +1,6 @@
 #include "camerainfo.h"
 
-CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
+CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QObject(parent)
 {
     m_cameraIndex = cameraIndex;
 
@@ -198,7 +198,7 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent) : QObject(parent)
     m_commonResolutions << QSize(1920, 1080);	// HD 1080, 1080i, 1080p
 #endif
 
-    m_webCamera = new cv::VideoCapture(m_cameraIndex);
+    m_webCamera = new cv::VideoCapture(m_cameraIndex + openCvBackend);
     if (m_webCamera && m_webCamera->open(m_cameraIndex)) {
         if (!queryResolutions()) {
             qDebug() << "Querying web camera resolutions failed";

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -3,6 +3,7 @@
 CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QObject(parent)
 {
     m_cameraIndex = cameraIndex;
+    m_cameraBackend = openCvBackend;
 
     // Source: https://en.wikipedia.org/wiki/List_of_common_resolutions (referenced 2016-05-02)
     // Used sections Common display formats, Video conferencing standards, Post-production
@@ -197,16 +198,21 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QO
     m_commonResolutions << QSize(1600, 900);	// 900p
     m_commonResolutions << QSize(1920, 1080);	// HD 1080, 1080i, 1080p
 #endif
+}
 
-    m_webCamera = new cv::VideoCapture(m_cameraIndex + openCvBackend);
+bool CameraInfo::init() {
+    bool ok = false;
+    m_webCamera = new cv::VideoCapture(m_cameraIndex + m_cameraBackend);
     if (m_webCamera && m_webCamera->open(m_cameraIndex)) {
-        if (!queryResolutions()) {
+        ok = queryResolutions();
+        if (!ok) {
             qDebug() << "Querying web camera resolutions failed";
         }
         m_webCamera->release();
     } else {
         qDebug() << "Problem creating and opening web camera" << m_cameraIndex;
     }
+    return ok;
 }
 
 QList<QSize> CameraInfo::availableResolutions() {
@@ -237,6 +243,7 @@ bool CameraInfo::queryResolutions() {
         /// @todo find out the nearest index at lower side if resolution not in list
         smallestIndex = 0;
     }
+    emit queryProgressChanged(1);
 
     // find largest supported resolution
     // Actually this test can be done in query loop below: just wait until size is larger than the last found
@@ -252,8 +259,10 @@ bool CameraInfo::queryResolutions() {
         /// @todo find out the nearest index at higher side if resolution not in list
         largestIndex = m_commonResolutions.size() - 1;
     }
+    emit queryProgressChanged(2);
 
     for (int i = smallestIndex; i < (largestIndex + 1); i++) {
+        int queryPercent = ((double)(i - smallestIndex) / (double)(largestIndex - smallestIndex)) * (100 - 4) + 3;
         testRes = m_commonResolutions.at(i);
         m_webCamera->set(CV_CAP_PROP_FRAME_WIDTH, testRes.width());
         m_webCamera->set(CV_CAP_PROP_FRAME_HEIGHT, testRes.height());
@@ -269,10 +278,12 @@ bool CameraInfo::queryResolutions() {
                 m_availableResolutions << newRes;
             }
         }
+        emit queryProgressChanged(queryPercent);
     }
 
     // finally sort the available resolutions first by width, then by height
     std::sort(m_availableResolutions.begin(), m_availableResolutions.end(), CameraInfo::compareResolutionsWidthFirst);
+    emit queryProgressChanged(100);
 
     return true;
 }

--- a/src/camerainfo.cpp
+++ b/src/camerainfo.cpp
@@ -151,7 +151,6 @@ CameraInfo::CameraInfo(int cameraIndex, QObject *parent, int openCvBackend) : QO
     m_commonResolutions << QSize(2048, 1536);
     m_commonResolutions << QSize(2048, 1556);
     m_commonResolutions << QSize(2160, 1440);
-    m_commonResolutions << QSize(2304, 1296);   // e.g. Logitech c920 undocumented resolution
     m_commonResolutions << QSize(2304, 1440);
     m_commonResolutions << QSize(2304, 1728);
     m_commonResolutions << QSize(2538, 1080);

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -22,8 +22,9 @@ public:
      * @brief CameraInfo
      * @param cameraIndex index of camera as used by OpenCV
      * @param parent
+     * @param openCvBackend backend for OpenCV VideoCapture object which is used by this class. Refer to VideoCapture::VideoCapture(int) for details.
      */
-    explicit CameraInfo(int cameraIndex, QObject *parent = 0);
+    explicit CameraInfo(int cameraIndex, QObject *parent = 0, int openCvBackend = CV_CAP_ANY);
 
     /**
      * @brief availableResolutions get list of available resolutions

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -11,6 +11,8 @@
 
 /**
  * @brief Get information of web camera
+ * NOTE: web camera must not be reserved when creating this object, so create
+ * this before using camera
  */
 class CameraInfo : public QObject
 {
@@ -42,13 +44,13 @@ public:
 private:
 #endif
     int m_cameraIndex;  ///< index of camera as used by OpenCV
-    cv::VideoCapture m_webCamera;
+    cv::VideoCapture* m_webCamera;
     QList<QSize> m_commonResolutions;   ///< common resolutions from Wikipedia
     QList<QSize> m_availableResolutions;    ///< results of resolution querying
 
     /**
      * @brief queryResolutions query available resolutions from web camera
-     * @return
+     * @return true if querying succeeded, false if it failed
      */
     bool queryResolutions();
 

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -27,6 +27,12 @@ public:
     explicit CameraInfo(int cameraIndex, QObject *parent = 0, int openCvBackend = CV_CAP_ANY);
 
     /**
+     * @brief init initialize
+     * @return true if initialization was successful, false otherwise
+     */
+    bool init();
+
+    /**
      * @brief availableResolutions get list of available resolutions
      * @return list of available resolutions
      */
@@ -45,6 +51,7 @@ public:
 private:
 #endif
     int m_cameraIndex;  ///< index of camera as used by OpenCV
+    int m_cameraBackend;    ///< camera backend as used by OpenCV
     cv::VideoCapture* m_webCamera;
     QList<QSize> m_commonResolutions;   ///< common resolutions from Wikipedia
     QList<QSize> m_availableResolutions;    ///< results of resolution querying
@@ -56,6 +63,11 @@ private:
     bool queryResolutions();
 
 signals:
+    /**
+     * @brief queryProgressChanged emitted when querying progresses
+     * @param percent percent of query ready
+     */
+    void queryProgressChanged(int percent);
 
 public slots:
 

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -39,6 +39,12 @@ public:
     QList<QSize> availableResolutions();
 
     /**
+     * @brief aspectRatios list of known web camera aspect ratios
+     * @return
+     */
+    QList<int> aspectRatios();
+
+    /**
      * @brief compareResolutionsWidthFirst compare resolutions giving precedence to width
      * This method is suitable to be given to std::sort as compare function
      * @param res1
@@ -54,6 +60,7 @@ private:
     int m_cameraBackend;    ///< camera backend as used by OpenCV
     cv::VideoCapture* m_webCamera;
     QList<QSize> m_commonResolutions;   ///< common resolutions from Wikipedia
+    QList<int> m_aspectRatios;          ///< aspect ratios (*10,000) for common and available resolutions
     QList<QSize> m_availableResolutions;    ///< results of resolution querying
 
     /**
@@ -61,6 +68,11 @@ private:
      * @return true if querying succeeded, false if it failed
      */
     bool queryResolutions();
+
+    /**
+     * @brief updateAspectRatios update aspect ratio list based on common and available resolutions
+     */
+    void updateAspectRatios();
 
 signals:
     /**

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -33,16 +33,22 @@ public:
     bool init();
 
     /**
+     * @brief isInitialized check whether this instance of CameraInfo is initialized
+     * @return true if initialized, false otherwise
+     */
+    bool isInitialized();
+
+    /**
      * @brief availableResolutions get list of available resolutions
      * @return list of available resolutions
      */
     QList<QSize> availableResolutions();
 
     /**
-     * @brief aspectRatios list of known web camera aspect ratios
+     * @brief knownAspectRatios list of known web camera aspect ratios
      * @return
      */
-    QList<int> aspectRatios();
+    QList<int> knownAspectRatios();
 
     /**
      * @brief compareResolutionsWidthFirst compare resolutions giving precedence to width
@@ -60,8 +66,9 @@ private:
     int m_cameraBackend;    ///< camera backend as used by OpenCV
     cv::VideoCapture* m_webCamera;
     QList<QSize> m_commonResolutions;   ///< common resolutions from Wikipedia
-    QList<int> m_aspectRatios;          ///< aspect ratios (*10,000) for common and available resolutions
+    QList<int> m_knownAspectRatios;          ///< aspect ratios (*10,000) for common and available resolutions
     QList<QSize> m_availableResolutions;    ///< results of resolution querying
+    bool m_initialized;
 
     /**
      * @brief queryResolutions query available resolutions from web camera

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -11,8 +11,6 @@
 
 /**
  * @brief Get information of web camera
- * NOTE: web camera must not be reserved when creating this object, so create
- * this before using camera
  */
 class CameraInfo : public QObject
 {
@@ -28,6 +26,10 @@ public:
 
     /**
      * @brief init initialize
+     *
+     * NOTE: web camera must not be reserved when calling this method so release
+     * the camera first
+     *
      * @return true if initialization was successful, false otherwise
      */
     bool init();

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -1,0 +1,50 @@
+#ifndef CAMERAINFO_H
+#define CAMERAINFO_H
+
+#include "opencv2/highgui/highgui.hpp"
+#include <QObject>
+#include <QList>
+#include <QSize>
+#include <QDebug>
+
+/**
+ * @brief Get information of web camera
+ */
+class CameraInfo : public QObject
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief CameraInfo
+     * @param cameraIndex index of camera as used by OpenCV
+     * @param parent
+     */
+    explicit CameraInfo(int cameraIndex, QObject *parent = 0);
+
+    /**
+     * @brief get list of available resolutions
+     * @return list of available resolutions
+     */
+    QList<QSize> availableResolutions();
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+    int m_cameraIndex;  ///< index of camera as used by OpenCV
+    cv::VideoCapture m_webCamera;
+    QList<QSize> m_commonResolutions;   ///< common resolutions from Wikipedia
+    QList<QSize> m_availableResolutions;    ///< results of resolution querying
+
+    /**
+     * @brief queryResolutions query available resolutions from web camera
+     * @return
+     */
+    bool queryResolutions();
+
+signals:
+
+public slots:
+
+};
+
+#endif // CAMERAINFO_H

--- a/src/camerainfo.h
+++ b/src/camerainfo.h
@@ -4,6 +4,8 @@
 #include "opencv2/highgui/highgui.hpp"
 #include <QObject>
 #include <QList>
+#include <list>     // for std::list::sort
+#include <algorithm>
 #include <QSize>
 #include <QDebug>
 
@@ -22,10 +24,19 @@ public:
     explicit CameraInfo(int cameraIndex, QObject *parent = 0);
 
     /**
-     * @brief get list of available resolutions
+     * @brief availableResolutions get list of available resolutions
      * @return list of available resolutions
      */
     QList<QSize> availableResolutions();
+
+    /**
+     * @brief compareResolutionsWidthFirst compare resolutions giving precedence to width
+     * This method is suitable to be given to std::sort as compare function
+     * @param res1
+     * @param res2
+     * @return true if res1 < res2 (precedence is on width)
+     */
+    static bool compareResolutionsWidthFirst(QSize res1, QSize res2);
 
 #ifndef _UNIT_TEST_
 private:

--- a/src/cameraresolutiondialog.cpp
+++ b/src/cameraresolutiondialog.cpp
@@ -1,0 +1,69 @@
+#include "cameraresolutiondialog.h"
+#include "ui_cameraresolutiondialog.h"
+
+CameraResolutionDialog::CameraResolutionDialog(Camera *camera, Config *config, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::CameraResolutionDialog)
+{
+    ui->setupUi(this);
+    m_camera = camera;
+    m_config = config;
+}
+
+CameraResolutionDialog::~CameraResolutionDialog() {
+    delete m_cameraInfo;
+    delete ui;
+}
+
+void CameraResolutionDialog::on_okPushButton_clicked() {
+    emit resolutionAccepted(ui->resolutionComboBox->currentData().toSize());
+    this->accept();
+}
+
+void CameraResolutionDialog::on_cancelPushButton_clicked() {
+    this->reject();
+}
+
+void CameraResolutionDialog::on_startQueryPushButton_clicked() {
+    qDebug() << "Starting query";
+    // can't query busy camera so release it first
+    m_camera->release();
+    ui->resolutionComboBox->setEnabled(true);
+    ui->queryProgressBar->setEnabled(true);
+    m_cameraInfo = new CameraInfo(m_config->cameraIndex());
+    connect(m_cameraInfo, SIGNAL(queryProgressChanged(int)), this, SLOT(onQueryProgressChanged(int)));
+    m_cameraInfo->init();
+
+    QSize currentResolution(m_config->cameraWidth(), m_config->cameraHeight());
+    QListIterator<QSize> resolutionListIt(m_cameraInfo->availableResolutions());
+    bool currentResolutionInList = false;
+    while (resolutionListIt.hasNext()) {
+        QSize resolution = resolutionListIt.next();
+        QString itemStr = QString::number(resolution.width()) + " x " + QString::number(resolution.height());
+        ui->resolutionComboBox->addItem(itemStr, QVariant(resolution));
+        // select current resolution if it's found
+        if (resolution == currentResolution) {
+            currentResolutionInList = true;
+            ui->resolutionComboBox->setCurrentIndex(ui->resolutionComboBox->count() - 1);
+        }
+    }
+    if (!currentResolutionInList) {
+        // show user nothing if non-matching resolution is given in settings
+        ui->resolutionComboBox->setCurrentIndex(ui->resolutionComboBox->count());
+    }
+    qDebug() << "Reinitializing camera";
+    m_camera->init();
+    qDebug() << "Camera reinitialization done";
+}
+
+void CameraResolutionDialog::on_resolutionComboBox_currentIndexChanged(int index) {
+    if ((index >= 0) && (index < ui->resolutionComboBox->count())) {
+        ui->okPushButton->setEnabled(true);
+    } else {
+        ui->okPushButton->setEnabled(false);
+    }
+}
+
+void CameraResolutionDialog::onQueryProgressChanged(int percent) {
+    ui->queryProgressBar->setValue(percent);
+}

--- a/src/cameraresolutiondialog.cpp
+++ b/src/cameraresolutiondialog.cpp
@@ -10,6 +10,8 @@ CameraResolutionDialog::CameraResolutionDialog(Camera *camera, Config *config, Q
     connect(m_camera, SIGNAL(queryProgressChanged(int)), this, SLOT(onQueryProgressChanged(int)));
     m_config = config;
 
+    ui->startQueryPushButton->setEnabled(m_camera->isInitialized());
+
     updateResolutionComboBox();
 }
 

--- a/src/cameraresolutiondialog.h
+++ b/src/cameraresolutiondialog.h
@@ -42,7 +42,8 @@ private:
     Ui::CameraResolutionDialog *ui;
     Config* m_config;
     Camera* m_camera;
-    CameraInfo* m_cameraInfo;
+
+    void updateResolutionComboBox();
 };
 
 #endif // CAMERARESOLUTIONDIALOG_H

--- a/src/cameraresolutiondialog.h
+++ b/src/cameraresolutiondialog.h
@@ -1,0 +1,48 @@
+#ifndef CAMERARESOLUTIONDIALOG_H
+#define CAMERARESOLUTIONDIALOG_H
+
+#include "config.h"
+#include "camera.h"
+#include "camerainfo.h"
+#include <QDialog>
+
+namespace Ui {
+class CameraResolutionDialog;
+}
+
+/**
+ * @brief The CameraResolutionDialog class
+ * Dialog for querying supported resolutions from camera
+ *
+ * @todo use cache so that don't need to query again when dialog is reopened; need to check camera is the same
+ */
+class CameraResolutionDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CameraResolutionDialog(Camera* camera, Config* config, QWidget *parent = 0);
+    ~CameraResolutionDialog();
+
+signals:
+    /**
+     * @brief resolutionAccepted emitted when user has selected and accepted a resolution and the dialog is closing
+     * @param resolution camera resolution
+     */
+    void resolutionAccepted(QSize resolution);
+
+public slots:
+    void on_okPushButton_clicked();
+    void on_cancelPushButton_clicked();
+    void on_startQueryPushButton_clicked();
+    void on_resolutionComboBox_currentIndexChanged(int index);
+    void onQueryProgressChanged(int percent);
+
+private:
+    Ui::CameraResolutionDialog *ui;
+    Config* m_config;
+    Camera* m_camera;
+    CameraInfo* m_cameraInfo;
+};
+
+#endif // CAMERARESOLUTIONDIALOG_H

--- a/src/cameraresolutiondialog.ui
+++ b/src/cameraresolutiondialog.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>257</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>400</width>
-    <height>0</height>
+    <height>300</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>450</width>
-    <height>300</height>
+    <height>350</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,2">
+    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,2,2,2">
      <property name="bottomMargin">
       <number>5</number>
      </property>
@@ -49,23 +49,58 @@
      </item>
      <item>
       <widget class="QLabel" name="label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="minimumSize">
         <size>
          <width>0</width>
-         <height>60</height>
+         <height>20</height>
         </size>
        </property>
        <property name="text">
-        <string>Querying the supported web camera resolutions causes problems with some web camera brands. Use at your own risk. If you get problems, reset camera settings in the settings file and contact the developers at contact@ufoid.net.</string>
+        <string>- Querying the supported web camera resolutions causes problems with some web camera brands. Use at your own risk.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>10</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>- Recommended to use only vendor-supported resolutions</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>- If you get problems, reset camera settings in the settings file and contact the developers at contact@ufoid.net.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="indent">
+        <number>10</number>
        </property>
       </widget>
      </item>

--- a/src/cameraresolutiondialog.ui
+++ b/src/cameraresolutiondialog.ui
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CameraResolutionDialog</class>
+ <widget class="QDialog" name="CameraResolutionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>257</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>450</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Query supported web camera resolutions</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,2">
+     <property name="bottomMargin">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>60</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Querying the supported web camera resolutions causes problems with some web camera brands. Use at your own risk. If you get problems, reset camera settings in the settings file and contact the developers at contact@ufoid.net.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Query status</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="queryProgressBar">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Available resolutions</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="resolutionComboBox">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="startQueryPushButton">
+       <property name="text">
+        <string>&amp;Start querying</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="okPushButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>&amp;OK</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelPushButton">
+       <property name="text">
+        <string>&amp;Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -7,6 +7,7 @@ Config::Config(QObject *parent) : QObject(parent)
     m_settingKeys[Config::CameraIndex] = "cameraIndex";
     m_settingKeys[Config::CameraWidth] = "cameraWidth";
     m_settingKeys[Config::CameraHeight] = "cameraHeight";
+    m_settingKeys[Config::CheckCameraAspectRatio] = "checkCameraAspectRatio";
     m_settingKeys[Config::DetectionAreaFile] = "detectionAreaFile";
     m_settingKeys[Config::DetectionAreaSize] = "detectionAreaSize";
     m_settingKeys[Config::NoiseFilterPixelSize] = "noiseFilterPixelSize";
@@ -30,6 +31,7 @@ Config::Config(QObject *parent) : QObject(parent)
     m_defaultCameraIndex = 0;
     m_defaultCameraWidth = 640;
     m_defaultCameraHeight = 480;
+    m_defaultCheckCameraAspectRatio = true;
 
     m_defaultNoiseFilterPixelSize = 2;
     m_defaultMotionThreshold = 10;
@@ -82,6 +84,10 @@ int Config::cameraWidth() {
 
 int Config::cameraHeight() {
     return m_settings->value(m_settingKeys[Config::CameraHeight], m_defaultCameraHeight).toInt();
+}
+
+bool Config::checkCameraAspectRatio() {
+    return m_settings->value(m_settingKeys[Config::CheckCameraAspectRatio], m_defaultCheckCameraAspectRatio).toBool();
 }
 
 QString Config::detectionAreaFile() {

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,7 @@ public:
         CameraIndex,        // camera
         CameraWidth,
         CameraHeight,
+        CheckCameraAspectRatio,
         DetectionAreaFile,  // detection parameters
         DetectionAreaSize,
         NoiseFilterPixelSize,
@@ -51,9 +52,10 @@ public:
 
     /**
      * @brief checkApplicationUpdates whether to automatically check application updates on startup
+     * This is a developer setting and needs to be added manually into the settings file.
      * @return true: check, false: don't check
      */
-    bool checkApplicationUpdates(); ///< whether to automatically check application updates
+    bool checkApplicationUpdates();
 
     /**
      * @brief cameraIndex web camera index as defined by OpenCV
@@ -69,6 +71,13 @@ public:
      * @brief cameraHeight web camera height in pixels
      */
     int cameraHeight();
+
+    /**
+     * @brief checkCameraAspectRatio checking web camera aspect ratio
+     * This is a developer setting and needs to be added manually into the settings file.
+     * @return true if checking, false if not
+     */
+    bool checkCameraAspectRatio();
 
     /**
      * @brief detectionAreaFile full name of file containing detection area definition
@@ -257,6 +266,7 @@ private:
     int m_defaultCameraIndex;
     int m_defaultCameraWidth;
     int m_defaultCameraHeight;
+    bool m_defaultCheckCameraAspectRatio;
 
     QString m_defaultDetectionDataDir; ///< default directory for data (detection area and result data / log)
     QString m_defaultDetectionAreaFileName; ///< default file name for detection area file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ int main(int argc, char *argv[])
 		QApplication a(argc, argv);
         Config myConfig;
         Camera myCam(myConfig.cameraIndex(), myConfig.cameraWidth(), myConfig.cameraHeight());
+        myCam.init();
         MainWindow w(0, &myCam, &myConfig);
         ActualDetector detector(&w, &myCam, &myConfig);
 		w.setSignalsAndSlots(&detector);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -107,9 +107,9 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
         {
             QDomElement element = node.toElement();
             VideoWidget* mytest = new VideoWidget(this, element.attribute("Pathname", "NULL"), element.attribute("DateTime", "NULL"),element.attribute("Length", "NULL")  );
-            connect(mytest->getClickableLabel(), SIGNAL(clicked()),this,SLOT(deletingFileAndRemovingItem()));
-            connect(mytest->getUploadLabel(), SIGNAL(clicked()),this,SLOT(createUploadWindow()));
-            connect(mytest->getPlayLabel(), SIGNAL(clicked()),this,SLOT(playClip()));
+            connect(mytest->deleteButton(), SIGNAL(clicked()),this,SLOT(deletingFileAndRemovingItem()));
+            connect(mytest->uploadButton(), SIGNAL(clicked()),this,SLOT(createUploadWindow()));
+            connect(mytest->playButton(), SIGNAL(clicked()),this,SLOT(playClip()));
             QListWidgetItem* item = new QListWidgetItem;
             item->setSizeHint(QSize(150,100));
             ui->videoList->addItem(item);
@@ -178,9 +178,9 @@ void MainWindow::setSignalsAndSlots(ActualDetector* ptrDetector)
 void MainWindow::updateWidgets(QString filename, QString datetime, QString videoLength)
 {
     VideoWidget* newWidget = new VideoWidget(this, filename, datetime, videoLength);
-    connect(newWidget->getClickableLabel(), SIGNAL(clicked()),this,SLOT(deletingFileAndRemovingItem()));
-    connect(newWidget->getUploadLabel(), SIGNAL(clicked()),this,SLOT(createUploadWindow()));
-    connect(newWidget->getPlayLabel(), SIGNAL(clicked()),this,SLOT(playClip()));
+    connect(newWidget->deleteButton(), SIGNAL(clicked()),this,SLOT(deletingFileAndRemovingItem()));
+    connect(newWidget->uploadButton(), SIGNAL(clicked()),this,SLOT(createUploadWindow()));
+    connect(newWidget->playButton(), SIGNAL(clicked()),this,SLOT(playClip()));
     QListWidgetItem* item = new QListWidgetItem;
     item->setSizeHint(QSize(150,100));
     ui->videoList->addItem(item);
@@ -202,9 +202,9 @@ void MainWindow::playClip()
             QListWidgetItem *item = ui->videoList->item(row);
             VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
 
-            if(widget->getPlayLabel()==sender())
+            if(widget->playButton()==sender())
             {
-                QDesktopServices::openUrl(QUrl::fromUserInput(widget->getPathname()));
+                QDesktopServices::openUrl(QUrl::fromUserInput(widget->videoFileName()));
             }
         }
     }
@@ -225,13 +225,14 @@ void MainWindow::deletingFileAndRemovingItem()
         QListWidgetItem *item = ui->videoList->item(row);
         VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
 
-        if(widget->getClickableLabel()==sender())
+        if(widget->deleteButton()==sender())
         {
-            qDebug() << "remove widget " << widget->getDateTime();
-            dateToRemove = widget->getDateTime();
+            dateToRemove = widget->dateTime();
             QListWidgetItem *itemToRemove = ui->videoList->takeItem(row);
             ui->videoList->removeItemWidget(itemToRemove);
-            QFile::remove(widget->getPathname());
+            qDebug() << "Removing" << widget->videoFileName() << "and its thumbnail";
+            QFile::remove(widget->videoFileName());
+            QFile::remove(widget->thumbnailFileName());
         }
     }
 
@@ -276,9 +277,9 @@ void MainWindow::createUploadWindow()
     {
         QListWidgetItem *item = ui->videoList->item(row);
         VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
-        if(widget->getUploadLabel()==sender())
+        if(widget->uploadButton()==sender())
         {
-            Uploader* upload = new Uploader(this,widget->getPathname(),m_config);
+            Uploader* upload = new Uploader(this,widget->videoFileName(),m_config);
             upload->show();
             upload->setAttribute(Qt::WA_DeleteOnClose);
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -112,8 +112,8 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
             connect(mytest->getPlayLabel(), SIGNAL(clicked()),this,SLOT(playClip()));
             QListWidgetItem* item = new QListWidgetItem;
             item->setSizeHint(QSize(150,100));
-            ui->myList->addItem(item);
-            ui->myList->setItemWidget(item,mytest);
+            ui->videoList->addItem(item);
+            ui->videoList->setItemWidget(item,mytest);
         }
         node = node.nextSibling();
     }
@@ -183,8 +183,8 @@ void MainWindow::updateWidgets(QString filename, QString datetime, QString video
     connect(newWidget->getPlayLabel(), SIGNAL(clicked()),this,SLOT(playClip()));
     QListWidgetItem* item = new QListWidgetItem;
     item->setSizeHint(QSize(150,100));
-    ui->myList->addItem(item);
-    ui->myList->setItemWidget(item,newWidget);
+    ui->videoList->addItem(item);
+    ui->videoList->setItemWidget(item,newWidget);
 
     recordingCounter_++;
     ui->lineCount->setText(QString::number(recordingCounter_));
@@ -197,10 +197,10 @@ void MainWindow::updateWidgets(QString filename, QString datetime, QString video
 void MainWindow::playClip()
 {
     if(!isRecording){
-        for(int row = 0; row < ui->myList->count(); row++)
+        for(int row = 0; row < ui->videoList->count(); row++)
         {
-            QListWidgetItem *item = ui->myList->item(row);
-            VideoWidget* widget = qobject_cast<VideoWidget*>(ui->myList->itemWidget(item));
+            QListWidgetItem *item = ui->videoList->item(row);
+            VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
 
             if(widget->getPlayLabel()==sender())
             {
@@ -220,17 +220,17 @@ void MainWindow::playClip()
 void MainWindow::deletingFileAndRemovingItem()
 {
     QString dateToRemove;
-    for(int row = 0; row < ui->myList->count(); row++)
+    for(int row = 0; row < ui->videoList->count(); row++)
     {
-        QListWidgetItem *item = ui->myList->item(row);
-        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->myList->itemWidget(item));
+        QListWidgetItem *item = ui->videoList->item(row);
+        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
 
         if(widget->getClickableLabel()==sender())
         {
             qDebug() << "remove widget " << widget->getDateTime();
             dateToRemove = widget->getDateTime();
-            QListWidgetItem *itemToRemove = ui->myList->takeItem(row);
-            ui->myList->removeItemWidget(itemToRemove);
+            QListWidgetItem *itemToRemove = ui->videoList->takeItem(row);
+            ui->videoList->removeItemWidget(itemToRemove);
             QFile::remove(widget->getPathname());
         }
     }
@@ -264,10 +264,7 @@ void MainWindow::deletingFileAndRemovingItem()
     }
     logFile.close();
     emit elementWasRemoved();
-
 }
-
-
 
 /*
  * Display the Upload Window
@@ -275,10 +272,10 @@ void MainWindow::deletingFileAndRemovingItem()
 void MainWindow::createUploadWindow()
 {
 
-    for(int row = 0; row < ui->myList->count(); row++)
+    for(int row = 0; row < ui->videoList->count(); row++)
     {
-        QListWidgetItem *item = ui->myList->item(row);
-        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->myList->itemWidget(item));
+        QListWidgetItem *item = ui->videoList->item(row);
+        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
         if(widget->getUploadLabel()==sender())
         {
             Uploader* upload = new Uploader(this,widget->getPathname(),m_config);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -83,11 +83,6 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     counterPositive_=0;
     recordingCounter_=0;
 
-    m_allowedWebcamAspectRatios << 12222;  // 11:9
-    m_allowedWebcamAspectRatios << 13333;  // 4:3
-    m_allowedWebcamAspectRatios << 15000;  // 3:2
-    m_allowedWebcamAspectRatios << 17777;  // 16:9
-
     checkFolders();
     readLogFileAndGetRootElement();
     checkDetectionAreaFile();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -272,7 +272,6 @@ void MainWindow::deletingFileAndRemovingItem()
  */
 void MainWindow::createUploadWindow()
 {
-
     for(int row = 0; row < ui->videoList->count(); row++)
     {
         QListWidgetItem *item = ui->videoList->item(row);
@@ -284,7 +283,6 @@ void MainWindow::createUploadWindow()
             upload->setAttribute(Qt::WA_DeleteOnClose);
         }
     }
-
 }
 
 /*
@@ -307,7 +305,6 @@ void MainWindow::setPositiveMessage()
     else ui->outputText->append(message + " - " + "Positive detection " + QString::number(++counterPositive_));
     lastWasPositive=true;
     lastWasInfo=false;
-
 }
 
 /*
@@ -411,16 +408,12 @@ void MainWindow::on_startButton_clicked()
         {
             ui->statusLabel->setText("Failed to start");
             connect(this,SIGNAL(updatePixmap(QImage)),this,SLOT(displayPixmap(QImage)));
-
         }
     }
     else
     {
         on_stopButton_clicked();
     }
-
-
-
 }
 
 void MainWindow::on_stopButton_clicked()
@@ -437,7 +430,6 @@ void MainWindow::on_stopButton_clicked()
         threadWebcam.reset(new std::thread(&MainWindow::updateWebcamFrame, this));
     }
     ui->startButton->setText("Start Detection");
-
 }
 
 void MainWindow::on_checkBox_stateChanged(int arg1)
@@ -477,20 +469,28 @@ void MainWindow::on_buttonImageExpl_clicked()
 bool MainWindow::checkAndSetResolution(const int WIDTH, const int HEIGHT)
 {
     double aspectRatio = (double)WIDTH / (double)HEIGHT;
+    /// @todo use actual maximum web camera view width AND height -- main window is resizable so view size changes
     int maxWebcamWidth = 640;
     int webcamHeight = (int)(maxWebcamWidth / aspectRatio);
+    bool aspectRatioOk = false;
 
     qDebug() << "Requested web cam size:" << QSize(WIDTH, HEIGHT);
     qDebug() << "Requested aspect ratio of web camera:" << aspectRatio;
-    for (int i=0; i < m_allowedWebcamAspectRatios.size(); i++)
+    if (m_config->checkCameraAspectRatio())
     {
-        if (m_allowedWebcamAspectRatios[i] == (int)(aspectRatio*10000))
+        if (CamPtr->knownAspectRatios().contains((int)(aspectRatio * 10000)))
         {
-            qDebug() << "Aspect ratio of web camera is ok";
-            ui->webcamView->resize(QSize(maxWebcamWidth, webcamHeight));
-            displayResolution = Size(maxWebcamWidth, webcamHeight);
-            return true;
+            aspectRatioOk = true;
         }
+    } else {
+        aspectRatioOk = true;
+    }
+    if (aspectRatioOk)
+    {
+        qDebug() << "Aspect ratio of web camera is ok";
+        ui->webcamView->resize(QSize(maxWebcamWidth, webcamHeight));
+        displayResolution = Size(maxWebcamWidth, webcamHeight);
+        return true;
     }
     qDebug() << "Aspect ratio of web camera is NOT ok";
     ui->outputText->append("Error: Selected webcam resolution is NOT ok");

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,7 +60,6 @@ private:
     Camera* CamPtr;
     std::unique_ptr<std::thread> threadWebcam;
     cv::Size displayResolution;
-    QList<int> m_allowedWebcamAspectRatios; ///< currently allowed webcam aspect ratios
 
     Config* m_config;
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -458,7 +458,7 @@
       <number>10</number>
      </property>
      <item>
-      <widget class="QListWidget" name="myList">
+      <widget class="QListWidget" name="videoList">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
          <horstretch>0</horstretch>

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -65,6 +65,9 @@ Recorder::Recorder(ActualDetector *parent, Camera *cameraPtr, Config *configPtr)
     case 13333:
         resolutionThumbnail = Size((640/10) + 15, (480/10) + 15);
         break;
+    case 15000:
+        resolutionThumbnail = Size((640/10) + 15, (320/10) + 15);
+        break;
     case 17777:
         resolutionThumbnail = Size((640/10) + 15, (360/10) + 15);
         break;

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -108,7 +108,10 @@ void SettingsDialog::saveSettings()
 void SettingsDialog::on_toolButtonVideoPath_clicked()
 {
     QString videoFilePath=QFileDialog::getExistingDirectory(this,tr("Select Directory"),QDir::currentPath(),QFileDialog::ShowDirsOnly);
-    ui->lineVideoPath->setText(videoFilePath);
+    if (!videoFilePath.isEmpty())
+    {
+        ui->lineVideoPath->setText(videoFilePath);
+    }
 }
 
 SettingsDialog::~SettingsDialog()
@@ -169,14 +172,20 @@ void SettingsDialog::on_toolButtonDetectionAreaFile_clicked()
     /// @todo use previous detection area file name if user cancels file selection
     QString detectionAreaFileName = QFileDialog::getOpenFileName(this,
         tr("Select the detection area file"),QDir::currentPath(), tr("XML file (*.xml)"));
-    ui->lineDetectionAreaFile->setText(detectionAreaFileName);
+    if (!detectionAreaFileName.isEmpty())
+    {
+        ui->lineDetectionAreaFile->setText(detectionAreaFileName);
+    }
 }
 
 void SettingsDialog::on_toolButtonImagePath_clicked()
 {
     QString imagePath = QFileDialog::getExistingDirectory(this, tr("Select Directory"),
         QDir::currentPath(), QFileDialog::ShowDirsOnly);
-    ui->lineImagePath->setText(imagePath);
+    if (!imagePath.isEmpty())
+    {
+        ui->lineImagePath->setText(imagePath);
+    }
 }
 
 void SettingsDialog::on_buttonSelectDetectionArea_clicked()

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -40,10 +40,25 @@ SettingsDialog::SettingsDialog(QWidget *parent, Camera *camPtr, Config *configPt
 
     int INDEX = m_config->cameraIndex();
     ui->comboBoxWebcam->setCurrentIndex(INDEX);
-    ui->lineW->setText(QString::number(m_config->cameraWidth()));
-    ui->lineH->setText(QString::number(m_config->cameraHeight()));
-    ui->lineW->setValidator(new QIntValidator(10, 1280, this));
-    ui->lineH->setValidator(new QIntValidator(10, 768, this));
+
+    QSize currentResolution(m_config->cameraWidth(), m_config->cameraHeight());
+    QListIterator<QSize> resolutionListIt(cameraPtr->availableResolutions());
+    bool currentResolutionInList = false;
+    while (resolutionListIt.hasNext())
+    {
+        QSize resolution = resolutionListIt.next();
+        QString itemStr = QString::number(resolution.width()) + " x " + QString::number(resolution.height());
+        ui->comboBoxResolution->addItem(itemStr, QVariant(resolution));
+        if (resolution == currentResolution) {
+            currentResolutionInList = true;
+            ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count() - 1);
+        }
+    }
+    if (!currentResolutionInList) {
+        // show user nothing if incorrect resolution given in settings
+        ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count());
+    }
+
     ui->lineVideoPath->setText(m_config->resultVideoDir());
     ui->lineDetectionAreaFile->setText(m_config->detectionAreaFile());
     ui->lineToken->setText(m_config->userTokenAtUfoId());
@@ -73,8 +88,9 @@ void SettingsDialog::saveSettings()
 {
     m_config->setResultVideoDir(ui->lineVideoPath->text());
     m_config->setCameraIndex(ui->comboBoxWebcam->currentIndex()); /// @todo cameraindex may change if cameras added/removed
-    m_config->setCameraWidth(ui->lineW->text().toInt());
-    m_config->setCameraHeight(ui->lineH->text().toInt());
+    QSize selectedResolution = ui->comboBoxResolution->currentData().toSize();
+    m_config->setCameraWidth(selectedResolution.width());
+    m_config->setCameraHeight(selectedResolution.height());
     m_config->setDetectionAreaFile(ui->lineDetectionAreaFile->text());
     m_config->setSaveResultImages(ui->checkBoxsaveImages->isChecked());
     m_config->setResultImageDir(ui->lineImagePath->text());

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -124,10 +124,19 @@ SettingsDialog::~SettingsDialog()
 
 void SettingsDialog::on_buttonSave_clicked()
 {
+    // check camera frame aspect ratio
+    int cameraWidth = ui->lineEditCameraWidth->text().toInt();
+    int cameraHeight = ui->lineEditCameraHeight->text().toInt();
+    int cameraAspectRatio =  (double)cameraWidth / (double)cameraHeight * 10000;
+    if (!cameraPtr->knownAspectRatios().contains(cameraAspectRatio))
+    {
+        QMessageBox::warning(this, "Error", "Unknown camera aspect ratio. Please change camera width and/or height. Settings are not saved.");
+        return;
+    }
     saveSettings();
     wasSaved=true;
     /// @todo apply settings on-the-fly
-    QMessageBox::information(this,"Information","Restart the application to apply the changes");
+    QMessageBox::information(this, "Information", "Settings saved successfully. Restart the application to apply the changes.");
 }
 
 void SettingsDialog::on_buttonCancel_clicked()

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -40,25 +40,10 @@ SettingsDialog::SettingsDialog(QWidget *parent, Camera *camPtr, Config *configPt
 
     int INDEX = m_config->cameraIndex();
     ui->comboBoxWebcam->setCurrentIndex(INDEX);
-
-    QSize currentResolution(m_config->cameraWidth(), m_config->cameraHeight());
-    QListIterator<QSize> resolutionListIt(cameraPtr->availableResolutions());
-    bool currentResolutionInList = false;
-    while (resolutionListIt.hasNext())
-    {
-        QSize resolution = resolutionListIt.next();
-        QString itemStr = QString::number(resolution.width()) + " x " + QString::number(resolution.height());
-        ui->comboBoxResolution->addItem(itemStr, QVariant(resolution));
-        if (resolution == currentResolution) {
-            currentResolutionInList = true;
-            ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count() - 1);
-        }
-    }
-    if (!currentResolutionInList) {
-        // show user nothing if incorrect resolution given in settings
-        ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count());
-    }
-
+    ui->lineEditCameraWidth->setText(QString::number(m_config->cameraWidth()));
+    ui->lineEditCameraHeight->setText(QString::number(m_config->cameraHeight()));
+    ui->lineEditCameraWidth->setValidator(new QIntValidator());
+    ui->lineEditCameraHeight->setValidator(new QIntValidator());
     ui->lineVideoPath->setText(m_config->resultVideoDir());
     ui->lineDetectionAreaFile->setText(m_config->detectionAreaFile());
     ui->lineToken->setText(m_config->userTokenAtUfoId());
@@ -77,7 +62,7 @@ SettingsDialog::SettingsDialog(QWidget *parent, Camera *camPtr, Config *configPt
 
     setWindowFlags(Qt::FramelessWindowHint);
     setWindowFlags(Qt::WindowTitleHint);
-    dialogIsOpened=false;
+    m_detectionAreaDialogIsOpen=false;
     wasSaved=false;
 
 //    connect(this,SIGNAL(finishedCheckingXML()),this,SLOT(cleanupThreadCheckXML()));
@@ -88,9 +73,8 @@ void SettingsDialog::saveSettings()
 {
     m_config->setResultVideoDir(ui->lineVideoPath->text());
     m_config->setCameraIndex(ui->comboBoxWebcam->currentIndex()); /// @todo cameraindex may change if cameras added/removed
-    QSize selectedResolution = ui->comboBoxResolution->currentData().toSize();
-    m_config->setCameraWidth(selectedResolution.width());
-    m_config->setCameraHeight(selectedResolution.height());
+    m_config->setCameraWidth(ui->lineEditCameraWidth->text().toInt());
+    m_config->setCameraHeight(ui->lineEditCameraHeight->text().toInt());
     m_config->setDetectionAreaFile(ui->lineDetectionAreaFile->text());
     m_config->setSaveResultImages(ui->checkBoxsaveImages->isChecked());
     m_config->setResultImageDir(ui->lineImagePath->text());
@@ -139,15 +123,16 @@ void SettingsDialog::on_buttonSave_clicked()
 {
     saveSettings();
     wasSaved=true;
+    /// @todo apply settings on-the-fly
     QMessageBox::information(this,"Information","Restart the application to apply the changes");
 }
 
 void SettingsDialog::on_buttonCancel_clicked()
 {
-    if(dialogIsOpened)
+    if(m_detectionAreaDialogIsOpen)
     {
-        myDialog->close();
-        delete myDialog;
+        m_detectionAreaDialog->close();
+        delete m_detectionAreaDialog;
     }
     this->close();
 //    if(!threadXMLfile)
@@ -202,12 +187,25 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
     }
     else
 	{
-        dialogIsOpened=true;
-        myDialog = new DetectionAreaEditDialog(0, cameraPtr, m_config);
-        myDialog->setModal(true);
-        myDialog->show();
+        m_detectionAreaDialogIsOpen=true;
+        m_detectionAreaDialog = new DetectionAreaEditDialog(0, cameraPtr, m_config);
+        m_detectionAreaDialog->setModal(true);
+        m_detectionAreaDialog->show();
         //connect(myDialog,SIGNAL(savedFile()),this,SLOT(startThreadCheckXML()));
     }
+}
+
+void SettingsDialog::on_toolButtonResolutionDialog_clicked()
+{
+    m_resolutionDialog = new CameraResolutionDialog(cameraPtr, m_config, this);
+    connect(m_resolutionDialog, SIGNAL(resolutionAccepted(QSize)), this, SLOT(onResolutionAcceptedInDialog(QSize)));
+    m_resolutionDialog->show();
+}
+
+void SettingsDialog::onResolutionAcceptedInDialog(QSize resolution)
+{
+    ui->lineEditCameraWidth->setText(QString::number(resolution.width()));
+    ui->lineEditCameraHeight->setText(QString::number(resolution.height()));
 }
 
 //void Settings::startThreadCheckXML()
@@ -226,12 +224,12 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
 //    }
 //}
 
-void SettingsDialog::on_toolButton_clicked()
+void SettingsDialog::on_toolButtonCodecHelp_clicked()
 {
     QMessageBox::information(this,"Codec Information","Raw Video results is big file sizes \nA lossless codec is recommended \nWindows 8 users should use the Lagarith Codec");
 }
 
-void SettingsDialog::on_toolButtonToken_clicked()
+void SettingsDialog::on_toolButtonTokenHelp_clicked()
 {
     QMessageBox::information(this,"UFOID.net User Token","Copy the User Token from your UFOID account in to this field to enable the upload feature\nThe code can be found at http://ufoid.net/profile/edit");
 }

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -21,10 +21,11 @@
 
 #include "config.h"
 #include "camera.h"
+#include "detectionareaeditdialog.h"
+#include "cameraresolutiondialog.h"
 #include <QDialog>
 #include <vector>
 #include <opencv2/opencv.hpp>
-#include "detectionareaeditdialog.h"
 #include <memory>
 #include <thread>
 
@@ -47,9 +48,11 @@ private:
     Camera* cameraPtr;
     Config* m_config;
     void saveSettings();
-    bool dialogIsOpened;
+    bool m_detectionAreaDialogIsOpen;
     bool wasSaved;
-    DetectionAreaEditDialog* myDialog;
+    DetectionAreaEditDialog* m_detectionAreaDialog;
+    CameraResolutionDialog* m_resolutionDialog;
+
     //std::unique_ptr<std::thread> threadXMLfile;
     //void checkAreaFile();
 
@@ -62,10 +65,12 @@ private slots:
     void on_toolButtonDetectionAreaFile_clicked();
     void on_toolButtonImagePath_clicked();
     void on_buttonSelectDetectionArea_clicked();
+    void on_toolButtonResolutionDialog_clicked();
+    void onResolutionAcceptedInDialog(QSize resolution);
     //void startThreadCheckXML();
     //void cleanupThreadCheckXML();
-    void on_toolButton_clicked();
-    void on_toolButtonToken_clicked();
+    void on_toolButtonCodecHelp_clicked();
+    void on_toolButtonTokenHelp_clicked();
 
 public slots:
 

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -20,6 +20,7 @@
 #define SETTINGS_H
 
 #include "config.h"
+#include "camera.h"
 #include <QDialog>
 #include <vector>
 #include <opencv2/opencv.hpp>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>518</width>
-    <height>436</height>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>10</x>
      <y>10</y>
      <width>491</width>
-     <height>419</height>
+     <height>447</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -35,182 +35,8 @@
     <property name="bottomMargin">
      <number>10</number>
     </property>
-    <item row="2" column="0">
-     <widget class="QLabel" name="labelCodec">
-      <property name="text">
-       <string>Video Codec:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0">
-     <widget class="QLabel" name="labelDetectionAreaFile">
-      <property name="text">
-       <string>Detection area file</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="buttonSelectDetectionArea">
-        <property name="text">
-         <string>Select detection area</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item row="4" column="1">
-     <widget class="QLineEdit" name="lineDetectionAreaFile">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="1">
-     <widget class="QLineEdit" name="lineImagePath">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true"/>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
     <item row="1" column="1">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="labelW">
-        <property name="text">
-         <string>Width:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="lineW"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="labelH">
-        <property name="text">
-         <string>Height:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="lineH"/>
-      </item>
-     </layout>
-    </item>
-    <item row="8" column="0" colspan="2">
-     <widget class="QCheckBox" name="checkBoxsaveImages">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="text">
-       <string>Save images</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="13" column="2">
-     <widget class="QToolButton" name="toolButtonToken">
-      <property name="text">
-       <string>?</string>
-      </property>
-     </widget>
-    </item>
-    <item row="13" column="1">
-     <widget class="QLineEdit" name="lineToken"/>
-    </item>
-    <item row="5" column="1">
-     <widget class="QLineEdit" name="lineStatus">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="labelWebcam">
-      <property name="text">
-       <string>Select Webcam:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="10" column="0" colspan="2">
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="labelMinPos">
-        <property name="text">
-         <string>Minimum required number of positive detections:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="lineMinPosRequired"/>
-      </item>
-     </layout>
-    </item>
-    <item row="9" column="2">
-     <widget class="QToolButton" name="toolButtonImagePath">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="text">
-       <string>...</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QComboBox" name="comboBoxCodec">
-      <item>
-       <property name="text">
-        <string>Raw Video</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>FFV1 Lossless Video</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>Lagarith Lossless Video</string>
-       </property>
-      </item>
-     </widget>
+     <widget class="QComboBox" name="comboBoxResolution"/>
     </item>
     <item row="3" column="2">
      <widget class="QToolButton" name="toolButtonVideoPath">
@@ -344,6 +170,159 @@
        </widget>
       </item>
      </layout>
+    </item>
+    <item row="8" column="0" colspan="2">
+     <widget class="QCheckBox" name="checkBoxsaveImages">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="text">
+       <string>Save images</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="13" column="2">
+     <widget class="QToolButton" name="toolButtonToken">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="13" column="1">
+     <widget class="QLineEdit" name="lineToken"/>
+    </item>
+    <item row="5" column="1">
+     <widget class="QLineEdit" name="lineStatus">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="labelWebcam">
+      <property name="text">
+       <string>Select Webcam:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="0" colspan="2">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelMinPos">
+        <property name="text">
+         <string>Minimum required number of positive detections:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineMinPosRequired"/>
+      </item>
+     </layout>
+    </item>
+    <item row="9" column="2">
+     <widget class="QToolButton" name="toolButtonImagePath">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QComboBox" name="comboBoxCodec">
+      <item>
+       <property name="text">
+        <string>Raw Video</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>FFV1 Lossless Video</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Lagarith Lossless Video</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="labelCodec">
+      <property name="text">
+       <string>Video Codec:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="labelDetectionAreaFile">
+      <property name="text">
+       <string>Detection area file</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="buttonSelectDetectionArea">
+        <property name="text">
+         <string>Select detection area</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLineEdit" name="lineDetectionAreaFile">
+      <property name="text">
+       <string/>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="1">
+     <widget class="QLineEdit" name="lineImagePath">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -36,7 +36,28 @@
      <number>10</number>
     </property>
     <item row="1" column="1">
-     <widget class="QComboBox" name="comboBoxResolution"/>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Width</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEditCameraWidth"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Height</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEditCameraHeight"/>
+      </item>
+     </layout>
     </item>
     <item row="3" column="2">
      <widget class="QToolButton" name="toolButtonVideoPath">
@@ -101,16 +122,9 @@
      </widget>
     </item>
     <item row="2" column="2">
-     <widget class="QToolButton" name="toolButton">
+     <widget class="QToolButton" name="toolButtonCodecHelp">
       <property name="text">
        <string>?</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="labelResolution">
-      <property name="text">
-       <string>Select Resolution:</string>
       </property>
      </widget>
     </item>
@@ -188,7 +202,7 @@
      </widget>
     </item>
     <item row="13" column="2">
-     <widget class="QToolButton" name="toolButtonToken">
+     <widget class="QToolButton" name="toolButtonTokenHelp">
       <property name="text">
        <string>?</string>
       </property>
@@ -321,6 +335,20 @@
       </property>
       <property name="readOnly">
        <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="QToolButton" name="toolButtonResolutionDialog">
+      <property name="text">
+       <string>...</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="labelResolution">
+      <property name="text">
+       <string>Select Resolution:</string>
       </property>
      </widget>
     </item>

--- a/src/videowidget.cpp
+++ b/src/videowidget.cpp
@@ -37,18 +37,16 @@ VideoWidget::VideoWidget(QWidget *parent, QString filepath, QString theDateTime,
 {
 
     myParent = qobject_cast<MainWindow*>(parent);
-    /// @todo take full file path from result data file
-    fullFilePath = filepath+QString("/Capture--")+theDateTime+QString(".avi");
-    dateTime = theDateTime;
-    /// @todo take full thumbnail path from result data file
-    thumbnailPath=filepath+QString("/thumbnails/")+theDateTime+QString(".jpg");
+    m_dateTime = theDateTime;
+    m_videoFileName = filepath + QString("/Capture--") + m_dateTime + QString(".avi");
+    m_thumbnailFileName=filepath + QString("/thumbnails/") + m_dateTime + QString(".jpg");
 
     QLabel *thumbnailLabel = new QLabel(this);
-    QLabel *lbl1 = new QLabel(dateTime, this);
+    QLabel *lbl1 = new QLabel(m_dateTime, this);
     QLabel *lbl2 = new QLabel(videoLength, this);
 
     QImage thumbnail;
-    thumbnail.load(thumbnailPath);
+    thumbnail.load(m_thumbnailFileName);
     thumbnailLabel->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     thumbnailLabel->setPixmap(QPixmap::fromImage(thumbnail));
 
@@ -62,18 +60,18 @@ VideoWidget::VideoWidget(QWidget *parent, QString filepath, QString theDateTime,
     hLayout->addLayout(vLayout);
 
     QHBoxLayout *hLayout2 = new QHBoxLayout;
-    smallPlay = new ClickableLabel(this);
-    smallPlay->setText("Play");
-    hLayout2->addWidget(smallPlay, 22, Qt::AlignRight);
+    m_playButton = new ClickableLabel(this);
+    m_playButton->setText("Play");
+    hLayout2->addWidget(m_playButton, 22, Qt::AlignRight);
 
-    smallUpload = new ClickableLabel(this);
-    smallUpload->setText("Share");
-    hLayout2->addWidget(smallUpload, 0, Qt::AlignRight);
+    m_uploadButton = new ClickableLabel(this);
+    m_uploadButton->setText("Share");
+    hLayout2->addWidget(m_uploadButton, 0, Qt::AlignRight);
 
-    smallRed = new ClickableLabel(this);
-    smallRed->setToolTip("Delete file from system and remove item from list");
-    smallRed->setText("Delete");
-    hLayout2->addWidget(smallRed, 0, Qt::AlignRight);
+    m_deleteButton = new ClickableLabel(this);
+    m_deleteButton->setToolTip("Delete file from system and remove item from list");
+    m_deleteButton->setText("Delete");
+    hLayout2->addWidget(m_deleteButton, 0, Qt::AlignRight);
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     mainLayout->addLayout(hLayout);
@@ -88,33 +86,38 @@ VideoWidget::VideoWidget(QWidget *parent, QString filepath, QString theDateTime,
 VideoWidget::~VideoWidget()
 {
     this->destroy(true,true);
-    delete smallRed;
+    delete m_deleteButton;
     delete this->layout();
 }
 
-ClickableLabel *VideoWidget::getClickableLabel()
+ClickableLabel *VideoWidget::deleteButton()
 {
-    return smallRed;
+    return m_deleteButton;
 }
 
-QString VideoWidget::getPathname()
+QString VideoWidget::videoFileName()
 {
-    return fullFilePath;
+    return m_videoFileName;
 }
 
-QString VideoWidget::getDateTime()
+QString VideoWidget::thumbnailFileName()
 {
-    return dateTime;
+    return m_thumbnailFileName;
 }
 
-ClickableLabel *VideoWidget::getUploadLabel()
+QString VideoWidget::dateTime()
 {
-    return smallUpload;
+    return m_dateTime;
 }
 
-ClickableLabel *VideoWidget::getPlayLabel()
+ClickableLabel *VideoWidget::uploadButton()
 {
-    return smallPlay;
+    return m_uploadButton;
+}
+
+ClickableLabel *VideoWidget::playButton()
+{
+    return m_playButton;
 }
 
 void VideoWidget::paintEvent(QPaintEvent *)

--- a/src/videowidget.h
+++ b/src/videowidget.h
@@ -28,6 +28,9 @@ namespace Ui {
 class VideoWidget;
 }
 
+/**
+ * @brief video widget to be used as list item
+ */
 class VideoWidget : public QWidget
 {
     Q_OBJECT
@@ -35,23 +38,24 @@ class VideoWidget : public QWidget
 public:
     explicit VideoWidget(QWidget *parent = 0, QString filepath = "", QString theDateTime = "", QString videoLength="");
     ~VideoWidget();
-    ClickableLabel* getClickableLabel();
-    QString getPathname();
-    QString getDateTime();
-    ClickableLabel* getUploadLabel();
-    ClickableLabel* getPlayLabel();
+    ClickableLabel* deleteButton();
+    QString videoFileName();
+    QString thumbnailFileName();
+    QString dateTime();
+    ClickableLabel* uploadButton();
+    ClickableLabel* playButton();
 
 
 private:
     Ui::VideoWidget *ui;
     void paintEvent(QPaintEvent *);
-    QString dateTime;
-    QString thumbnailPath;
-    QString fullFilePath;
+    QString m_dateTime;
+    QString m_thumbnailFileName;
+    QString m_videoFileName;
     MainWindow* myParent;
-    ClickableLabel *smallRed;
-    ClickableLabel *smallUpload;
-    ClickableLabel *smallPlay;
+    ClickableLabel *m_deleteButton;
+    ClickableLabel *m_uploadButton;
+    ClickableLabel *m_playButton;
 
 
 signals:

--- a/test/testCameraInfo/testCameraInfo.pro
+++ b/test/testCameraInfo/testCameraInfo.pro
@@ -1,0 +1,55 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2016-05-01T15:52:57
+#
+#-------------------------------------------------
+
+QT       += testlib
+
+QT       -= gui
+
+TARGET = testcamerainfo
+CONFIG   += console
+CONFIG   -= app_bundle
+
+TEMPLATE = app
+
+INCLUDEPATH += ../../src
+
+HEADERS += ../../src/camerainfo.h
+
+SOURCES += testcamerainfo.cpp \
+    ../../src/camerainfo.cpp
+
+DEFINES += SRCDIR=\\\"$$PWD/\\\" \
+    _UNIT_TEST_
+
+windows {
+    INCLUDEPATH += C:\own\install\include
+    LIBS += C:\own\bin\libopencv_core300.dll
+    LIBS += C:\own\bin\libopencv_highgui300.dll
+    LIBS += C:\own\bin\libopencv_imgproc300.dll
+    LIBS += C:\own\bin\libopencv_calib3d300.dll
+    LIBS += C:\own\bin\libopencv_features2d300.dll
+    LIBS += C:\own\bin\libopencv_flann300.dll
+    LIBS += C:\own\bin\libopencv_ml300.dll
+    LIBS += C:\own\bin\libopencv_objdetect300.dll
+    LIBS += C:\own\bin\libopencv_video300.dll
+    LIBS += C:\own\bin\libopencv_videoio300.dll
+    LIBS += C:\own\bin\libopencv_imgcodecs300.dll
+}
+
+unix {
+    INCLUDEPATH += /usr/include/opencv2/
+    LIBS += -lopencv_core
+    LIBS += -lopencv_highgui
+    LIBS += -lopencv_imgproc
+    LIBS += -lopencv_calib3d
+    LIBS += -lopencv_features2d
+    LIBS += -lopencv_flann
+    LIBS += -lopencv_ml
+    LIBS += -lopencv_objdetect
+    LIBS += -lopencv_video
+    #LIBS += -lopencv_videoio
+    #LIBS += -lopencv_imgcodecs
+}

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -47,6 +47,7 @@ void TestCameraInfo::initTestCase()
     QVERIFY(NULL != m_cameraInfo);
     QVERIFY(m_cameraInfo->m_commonResolutions.size() > 0);
     QVERIFY(m_cameraInfo->m_availableResolutions.isEmpty());
+    QVERIFY(!m_cameraInfo->m_knownAspectRatios.isEmpty());
     connect(m_cameraInfo, SIGNAL(queryProgressChanged(int)), this, SLOT(onQueryProgressChanged(int)));
 }
 
@@ -60,13 +61,21 @@ void TestCameraInfo::cleanupTestCase()
 void TestCameraInfo::cameraInfoInit()
 {
     QVERIFY(m_cameraInfo->m_availableResolutions.isEmpty());
-    QVERIFY(m_cameraInfo->m_aspectRatios.isEmpty());
+    QVERIFY(m_cameraInfo->availableResolutions().isEmpty());
+    QVERIFY(!m_cameraInfo->m_knownAspectRatios.isEmpty());
+    QVERIFY(!m_cameraInfo->knownAspectRatios().isEmpty());
+    QVERIFY(!m_cameraInfo->m_initialized);
+    QVERIFY(!m_cameraInfo->isInitialized());
     QVERIFY(m_queryProgressEmitted.isEmpty());
 
     QVERIFY(m_cameraInfo->init());
 
     QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
-    QVERIFY(!m_cameraInfo->m_aspectRatios.isEmpty());
+    QVERIFY(!m_cameraInfo->availableResolutions().isEmpty());
+    QVERIFY(!m_cameraInfo->m_knownAspectRatios.isEmpty());
+    QVERIFY(!m_cameraInfo->knownAspectRatios().isEmpty());
+    QVERIFY(m_cameraInfo->m_initialized);
+    QVERIFY(m_cameraInfo->isInitialized());
     QVERIFY(m_queryProgressEmitted.contains(1));    // lowest resolution
     QVERIFY(m_queryProgressEmitted.contains(2));    // highest resolution
     QVERIFY(m_queryProgressEmitted.contains(100));  // query done
@@ -74,7 +83,7 @@ void TestCameraInfo::cameraInfoInit()
     /// @todo check aspect ratio is found for each common and available resolution
 
     qDebug() << "Web camera aspect ratios known by CameraInfo:";
-    QListIterator<int> aspIt(m_cameraInfo->m_aspectRatios);
+    QListIterator<int> aspIt(m_cameraInfo->m_knownAspectRatios);
     while (aspIt.hasNext()) {
         qDebug() << aspIt.next();
     }

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -33,7 +33,12 @@ TestCameraInfo::TestCameraInfo()
 
 void TestCameraInfo::initTestCase()
 {
+    QTime duration;
+    int msec;
+    duration.start();
     m_cameraInfo = new CameraInfo(0);
+    msec = duration.elapsed();
+    qDebug() << "Querying web camera resolutions took" << (double)msec/1000 << "s";
 }
 
 void TestCameraInfo::cleanupTestCase()

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -28,18 +28,17 @@ private Q_SLOTS:
 
 private:
     CameraInfo* m_cameraInfo;
-    int m_lastQueryProgress;
+    QList<int> m_queryProgressEmitted;  ///< list of resolution query progress percentages emitted
 };
 
 TestCameraInfo::TestCameraInfo()
 {
     qDebug() << "NOTE: THIS UNIT TEST REQUIRES A WEB CAMERA";
     m_cameraInfo = NULL;
-    m_lastQueryProgress = 0;
 }
 
 void TestCameraInfo::onQueryProgressChanged(int progress) {
-    m_lastQueryProgress = progress;
+    m_queryProgressEmitted << progress;
 }
 
 void TestCameraInfo::initTestCase()
@@ -61,16 +60,23 @@ void TestCameraInfo::cleanupTestCase()
 void TestCameraInfo::cameraInfoInit()
 {
     QVERIFY(m_cameraInfo->m_availableResolutions.isEmpty());
-    QVERIFY(0 == m_lastQueryProgress);
-    QVERIFY(m_cameraInfo->init());
-    QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
-    QVERIFY(100 == m_lastQueryProgress);
+    QVERIFY(m_cameraInfo->m_aspectRatios.isEmpty());
+    QVERIFY(m_queryProgressEmitted.isEmpty());
 
-    QListIterator<QSize> listIt(m_cameraInfo->m_availableResolutions);
-    qDebug() << "Resolutions found in unit test:";
-    while (listIt.hasNext()) {
-        QSize resolution = (QSize)listIt.next();
-        qDebug() << resolution.width() << "x" << resolution.height();
+    QVERIFY(m_cameraInfo->init());
+
+    QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
+    QVERIFY(!m_cameraInfo->m_aspectRatios.isEmpty());
+    QVERIFY(m_queryProgressEmitted.contains(1));    // lowest resolution
+    QVERIFY(m_queryProgressEmitted.contains(2));    // highest resolution
+    QVERIFY(m_queryProgressEmitted.contains(100));  // query done
+
+    /// @todo check aspect ratio is found for each common and available resolution
+
+    qDebug() << "Web camera aspect ratios known by CameraInfo:";
+    QListIterator<int> aspIt(m_cameraInfo->m_aspectRatios);
+    while (aspIt.hasNext()) {
+        qDebug() << aspIt.next();
     }
 }
 

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -44,7 +44,7 @@ void TestCameraInfo::cleanupTestCase()
 
 void TestCameraInfo::queryResolutions()
 {
-    QVERIFY(m_cameraInfo->queryResolutions());
+    //QVERIFY(m_cameraInfo->queryResolutions());    // this is already done in constructor
     QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
     QListIterator<QSize> listIt(m_cameraInfo->m_availableResolutions);
     qDebug() << "Resolutions found in unit test:";

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -3,6 +3,11 @@
 #include <QString>
 #include <QtTest>
 
+/**
+ * @brief The TestCameraInfo class unit test for CameraInfo class
+ * Drawback: needs a real web camera at the moment. If you know how to make
+ * a mock object of cv::VideoCapture please tell it. :)
+ */
 class TestCameraInfo : public QObject
 {
     Q_OBJECT
@@ -14,6 +19,8 @@ private Q_SLOTS:
     void initTestCase();
     void cleanupTestCase();
     void queryResolutions();
+    void compareResolutionsWidthFirst();
+    void testListSorting();
 
 private:
     CameraInfo* m_cameraInfo;
@@ -21,6 +28,7 @@ private:
 
 TestCameraInfo::TestCameraInfo()
 {
+    qDebug() << "NOTE: THIS UNIT TEST REQUIRES A WEB CAMERA";
 }
 
 void TestCameraInfo::initTestCase()
@@ -38,6 +46,96 @@ void TestCameraInfo::queryResolutions()
 {
     QVERIFY(m_cameraInfo->queryResolutions());
     QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
+    QListIterator<QSize> listIt(m_cameraInfo->m_availableResolutions);
+    qDebug() << "Resolutions found in unit test:";
+    while (listIt.hasNext()) {
+        QSize resolution = (QSize)listIt.next();
+        qDebug() << resolution.width() << "x" << resolution.height();
+    }
+}
+
+void TestCameraInfo::compareResolutionsWidthFirst() {
+    QSize res1;
+    QSize res2;
+
+    // res1 < res2, both width and height
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(20);
+    res2.setHeight(20);
+    QVERIFY(CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 < res2, only width, height equal
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(20);
+    res2.setHeight(10);
+    QVERIFY(CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 < res2, only width, height less in res2
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(20);
+    res2.setHeight(0);
+    QVERIFY(CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 == res2, both width and height
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(10);
+    res2.setHeight(10);
+    QVERIFY(!CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 == res2, width equal, height larger in res2
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(10);
+    res2.setHeight(20);
+    QVERIFY(CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 == res2, width equal, height smaller in res2
+    res1.setWidth(10);
+    res1.setHeight(10);
+    res2.setWidth(10);
+    res2.setHeight(0);
+    QVERIFY(!CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 > res2, res2 width is smaller, otherwise equal
+    res1.setWidth(20);
+    res1.setHeight(10);
+    res2.setWidth(10);
+    res2.setHeight(10);
+    QVERIFY(!CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 > res2, res2 width and height are smaller
+    res1.setWidth(20);
+    res1.setHeight(20);
+    res2.setWidth(10);
+    res2.setHeight(10);
+    QVERIFY(!CameraInfo::compareResolutionsWidthFirst(res1, res2));
+
+    // res1 > res2, res2 height is smaller, width is same
+    res1.setWidth(10);
+    res1.setHeight(20);
+    res2.setWidth(10);
+    res2.setHeight(10);
+    QVERIFY(!CameraInfo::compareResolutionsWidthFirst(res1, res2));
+}
+
+void TestCameraInfo::testListSorting() {
+    QList<QSize> testList;
+    testList << QSize(50, 10);
+    testList << QSize(20, 40);
+    testList << QSize(10, 50);
+    testList << QSize(20, 20);
+    testList << QSize(20, 30);
+
+    std::sort(testList.begin(), testList.end(), CameraInfo::compareResolutionsWidthFirst);
+    QVERIFY(testList.at(0) == QSize(10, 50));
+    QVERIFY(testList.at(1) == QSize(20, 20));
+    QVERIFY(testList.at(2) == QSize(20, 30));
+    QVERIFY(testList.at(3) == QSize(20, 40));
+    QVERIFY(testList.at(4) == QSize(50, 10));
 }
 
 QTEST_APPLESS_MAIN(TestCameraInfo)

--- a/test/testCameraInfo/testcamerainfo.cpp
+++ b/test/testCameraInfo/testcamerainfo.cpp
@@ -1,0 +1,45 @@
+
+#include "camerainfo.h"
+#include <QString>
+#include <QtTest>
+
+class TestCameraInfo : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestCameraInfo();
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+    void queryResolutions();
+
+private:
+    CameraInfo* m_cameraInfo;
+};
+
+TestCameraInfo::TestCameraInfo()
+{
+}
+
+void TestCameraInfo::initTestCase()
+{
+    m_cameraInfo = new CameraInfo(0);
+}
+
+void TestCameraInfo::cleanupTestCase()
+{
+    delete m_cameraInfo;
+    m_cameraInfo = NULL;
+}
+
+void TestCameraInfo::queryResolutions()
+{
+    QVERIFY(m_cameraInfo->queryResolutions());
+    QVERIFY(!m_cameraInfo->m_availableResolutions.isEmpty());
+}
+
+QTEST_APPLESS_MAIN(TestCameraInfo)
+
+#include "testcamerainfo.moc"

--- a/test/testConfig/testconfig.cpp
+++ b/test/testConfig/testconfig.cpp
@@ -12,6 +12,7 @@ public:
 private Q_SLOTS:
     void init();
     void cleanup();
+    void testDefaultValues();
     void testMotionThreshold();
 
 private:
@@ -34,9 +35,39 @@ void TestConfig::init() {
 
 void TestConfig::cleanup() {
     QFile settingsFile(m_config->m_settings->fileName());
-    QVERIFY(settingsFile.remove());
+    if (settingsFile.exists()) {
+        QVERIFY(settingsFile.remove());
+    }
     delete m_config;
     m_config = NULL;
+}
+
+void TestConfig::testDefaultValues() {
+    QVERIFY(m_config->applicationVersion() == "");
+    QVERIFY(m_config->checkApplicationUpdates() == true);
+
+    QVERIFY(m_config->cameraIndex() == 0);
+    QVERIFY(m_config->cameraWidth() == 640);
+    QVERIFY(m_config->cameraHeight() == 480);
+    QVERIFY(m_config->checkCameraAspectRatio() == true);
+
+    //QVERIFY(m_config->detectionAreaFile());
+    QVERIFY(m_config->detectionAreaSize() == 0);
+
+    QVERIFY(m_config->noiseFilterPixelSize() == 2);
+    QVERIFY(m_config->motionThreshold() == 10);
+    QVERIFY(m_config->minPositiveDetections() == 2);
+    //QVERIFY(m_config->birdClassifierTrainingFile());
+
+    //QVERIFY(m_config->resultDataFile());
+    //QVERIFY(m_config->resultVideoDir());
+    QVERIFY(m_config->resultVideoCodec() == 1);
+    QVERIFY(m_config->resultVideoWithObjectRectangles() == false);
+    //QVERIFY(m_config->videoEncoderLocation());
+    //QVERIFY(m_config->resultImageDir());
+    QVERIFY(m_config->saveResultImages() == false);
+
+    QVERIFY(m_config->userTokenAtUfoId() == "");
 }
 
 void TestConfig::testMotionThreshold() {


### PR DESCRIPTION
- created CameraInfo class to get resolutions + tested class (not well though)
- added CameraInfo into Camera class
- showing resolution combo box in settings dialog, removed earlier width and height fields
- not possible to give resolution manually anymore except in config file
- aspect ratio check remains here and there but could be removed
- not tested whether querying works with more web camera brands (I used an old Logitech cam)
