### PR TITLE
Mostly improved Camera-related unit testing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -127,6 +127,7 @@ void MainWindow::updateWebcamFrame()
         m_cameraViewImage = QImage((uchar*)resizedFrame.data, resizedFrame.cols, resizedFrame.rows, resizedFrame.step, QImage::Format_RGB888);
         m_cameraViewImageMutex.unlock();
         emit updatePixmap(m_cameraViewImage);
+        std::this_thread::yield();
     }
 }
 

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -121,11 +121,12 @@ void Recorder::recordThread(){
             currentTime = std::chrono::high_resolution_clock::now();
             difference = currentTime - prevTime;
         }
-
+        m_currentFrameMutex.lock();
         if (m_currentFrame.data)
         {
             m_videoWriter.write(m_currentFrame);
         }
+        m_currentFrameMutex.unlock();
 
         prevTime = std::chrono::time_point_cast<hr_duration>(prevTime + frame_period{ 1 });
         difference = currentTime - prevTime;
@@ -228,7 +229,9 @@ void Recorder::readFrameThread()
             rectangle(temp, m_motionRectangle, m_objectRectangleColor);
             oldRectangle=m_motionRectangle;
         }
+        m_currentFrameMutex.lock();
         temp.copyTo(m_currentFrame);
+        m_currentFrameMutex.unlock();
     }
 }
 

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -130,6 +130,7 @@ void Recorder::recordThread(){
 
         prevTime = std::chrono::time_point_cast<hr_duration>(prevTime + frame_period{ 1 });
         difference = currentTime - prevTime;
+        std::this_thread::yield();
     }
 
     m_videoWriter.release();
@@ -232,6 +233,7 @@ void Recorder::readFrameThread()
         m_currentFrameMutex.lock();
         temp.copyTo(m_currentFrame);
         m_currentFrameMutex.unlock();
+        std::this_thread::yield();
     }
 }
 

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -31,6 +31,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QCoreApplication>
+#include <QMutex>
 #include <atomic>
 #include <thread>
 #include <memory>
@@ -84,6 +85,7 @@ private:
 
     std::unique_ptr<std::thread> m_recorderThread;
     std::unique_ptr<std::thread> m_frameUpdateThread;
+    QMutex m_currentFrameMutex;     ///< mutex for synchronizing access to m_currentFrame
     std::atomic<bool>  m_recording;
     bool m_willSaveVideo;       ///< whether to save video or reject it
     bool m_drawRectangles;      ///< whether or not to draw rectangles around detected objects

--- a/test/mock/mockCTracker.cpp
+++ b/test/mock/mockCTracker.cpp
@@ -1,0 +1,41 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Ctracker.h"
+#include <QObject>
+
+
+CTracker::CTracker(float _dt, float _Accel_noise_mag, double _dist_thres,
+    int _maximum_allowed_skipped_frames, int _max_trace_length)
+{
+    Q_UNUSED(_dt);
+    Q_UNUSED(_Accel_noise_mag);
+    Q_UNUSED(_dist_thres);
+    Q_UNUSED(_maximum_allowed_skipped_frames);
+    Q_UNUSED(_max_trace_length);
+}
+
+CTracker::~CTracker() {
+}
+
+void CTracker::Update(vector<Point2d> &detections) {
+    Q_UNUSED(detections);
+}
+
+void CTracker::updateEmpty() {
+}

--- a/test/mock/mockDetector.cpp
+++ b/test/mock/mockDetector.cpp
@@ -1,0 +1,32 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Detector.h"
+#include <QObject>
+
+CDetector::CDetector(Mat &gray) {
+    Q_UNUSED(gray);
+}
+
+CDetector::~CDetector() {
+}
+
+pair<vector<Point2d>, vector<Rect>> CDetector::Detect(Mat &gray, Rect &croppedRect) {
+    Q_UNUSED(gray);
+    Q_UNUSED(croppedRect);
+}

--- a/test/mock/mockDetector.cpp
+++ b/test/mock/mockDetector.cpp
@@ -29,4 +29,7 @@ CDetector::~CDetector() {
 pair<vector<Point2d>, vector<Rect>> CDetector::Detect(Mat &gray, Rect &croppedRect) {
     Q_UNUSED(gray);
     Q_UNUSED(croppedRect);
+    vector<Point2d> pointVector;
+    vector<Rect> rectVector;
+    return std::make_pair(pointVector, rectVector);
 }

--- a/test/mock/mockMainWindow.cpp
+++ b/test/mock/mockMainWindow.cpp
@@ -1,0 +1,100 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mainwindow.h"
+
+MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) {
+    Q_UNUSED(parent);
+    Q_UNUSED(cameraPtr);
+    m_config = configPtr;
+}
+
+MainWindow::~MainWindow() {
+}
+
+void MainWindow::addOutputText(QString msg) {
+    Q_UNUSED(msg);
+}
+
+bool MainWindow::getCheckboxDisplayWebcamState() {
+    return false;
+}
+
+void MainWindow::setSignalsAndSlots(ActualDetector *actualDetector) {
+    Q_UNUSED(actualDetector);
+}
+
+cv::Size MainWindow::getCameraViewSize() {
+    return cv::Size(m_config->cameraWidth(), m_config->cameraHeight());
+}
+
+QMutex* MainWindow::cameraViewImageMutex() {
+    return &m_cameraViewImageMutex;
+}
+
+void MainWindow::setLatestStillFrame(cv::Mat& frame) {
+    Q_UNUSED(frame);
+}
+
+
+void MainWindow::onRecordingStarted() {
+}
+
+void MainWindow::onRecordingFinished() {
+}
+
+void MainWindow::on_progressBar_valueChanged(int value) {
+    Q_UNUSED(value);
+}
+
+void MainWindow::update_output_text(QString msg) {
+    Q_UNUSED(msg);
+}
+
+void MainWindow::displayPixmap(QImage img) {
+    Q_UNUSED(img);
+}
+
+void MainWindow::on_startButton_clicked() { }
+void MainWindow::on_checkBoxDisplayWebcam_stateChanged(int arg1) { Q_UNUSED(arg1); }
+void MainWindow::on_buttonClear_clicked() { }
+void MainWindow::on_sliderNoise_sliderMoved(int position) { Q_UNUSED(position); }
+void MainWindow::on_settingsButton_clicked() { }
+void MainWindow::on_recordingTestButton_clicked() { }
+void MainWindow::onVideoPlayClicked() { }
+void MainWindow::onVideoDeleteClicked() { }
+void MainWindow::onVideoUploadClicked() { }
+void MainWindow::onVideoListContextMenuRequested(const QPoint& pos) { Q_UNUSED(pos); }
+void MainWindow::onDeleteSelectedVideosClicked() { }
+void MainWindow::setPositiveMessage() { }
+void MainWindow::setNegativeMessage() { }
+void MainWindow::setErrorReadingDetectionAreaFile() { }
+void MainWindow::addVideoToVideoList(QString filename, QString datetime, QString videoLength) {
+    Q_UNUSED(filename);
+    Q_UNUSED(datetime);
+    Q_UNUSED(videoLength);
+}
+void MainWindow::on_aboutButton_clicked() { }
+void MainWindow::checkForUpdate(QNetworkReply* reply) { Q_UNUSED(reply); }
+void MainWindow::on_buttonImageExpl_clicked() { }
+void MainWindow::on_sliderThresh_sliderMoved(int position) { Q_UNUSED(position); }
+void MainWindow::on_toolButtonNoise_clicked() { }
+void MainWindow::on_toolButtonThresh_clicked() { }
+void MainWindow::showEvent(QShowEvent *event) { Q_UNUSED(event); }
+void MainWindow::resizeEvent(QResizeEvent *event) { Q_UNUSED(event); }
+void MainWindow::closeEvent(QCloseEvent *event) { Q_UNUSED(event); }

--- a/test/mock/mockRecorder.cpp
+++ b/test/mock/mockRecorder.cpp
@@ -1,0 +1,48 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "recorder.h"
+
+Recorder::Recorder(Camera* cameraPtr, Config* configPtr) {
+    Q_UNUSED(cameraPtr);
+    Q_UNUSED(configPtr);
+}
+
+void Recorder::startRecording(cv::Mat &firstFrame) {
+    Q_UNUSED(firstFrame);
+}
+
+void Recorder::stopRecording(bool willSaveVideo) {
+    Q_UNUSED(willSaveVideo);
+}
+
+void Recorder::setRectangle(cv::Rect &r, bool isRed) {
+    Q_UNUSED(r);
+    Q_UNUSED(isRed);
+}
+
+void Recorder::reloadResultDataFile() {
+}
+
+void Recorder::startEncodingVideoToFFV1(QString tempVideoFileName, QString targetVideoFileName) {
+    Q_UNUSED(tempVideoFileName);
+    Q_UNUSED(targetVideoFileName);
+}
+
+void Recorder::onVideoEncodingFinished() {
+}

--- a/test/mock/mockcamera.cpp
+++ b/test/mock/mockcamera.cpp
@@ -1,3 +1,21 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "camera.h"
 
 cv::Mat mockCameraNextFrame;    ///< next frame which Camera::getWebcamFrame() will give

--- a/test/mock/mockconfig.cpp
+++ b/test/mock/mockconfig.cpp
@@ -1,3 +1,21 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "config.h"
 
 QString mockConfigResultDataDir;

--- a/test/testActualDetector/testActualDetector.cpp
+++ b/test/testActualDetector/testActualDetector.cpp
@@ -1,0 +1,82 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "actualdetector.h"
+#include "mainwindow.h"
+#include "config.h"
+#include "camera.h"
+#include <QString>
+#include <QtTest>
+#include <QCoreApplication>
+
+class TestActualDetector : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestActualDetector();
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+    void constructor();
+
+private:
+    ActualDetector* m_actualDetector;
+    MainWindow* m_mainWindow;
+    Config* m_config;
+    Camera* m_camera;
+};
+
+TestActualDetector::TestActualDetector()
+{
+}
+
+void TestActualDetector::initTestCase()
+{
+    m_config = new Config();
+    QVERIFY(NULL != m_config);
+    m_camera = new Camera(m_config->cameraIndex(), m_config->cameraWidth(), m_config->cameraHeight());
+    QVERIFY(NULL != m_camera);
+    m_mainWindow = new MainWindow(NULL, m_camera, m_config);
+    QVERIFY(NULL != m_mainWindow);
+    m_actualDetector = new ActualDetector(m_mainWindow, m_camera, m_config);
+    QVERIFY(NULL != m_actualDetector);
+}
+
+void TestActualDetector::cleanupTestCase()
+{
+    m_actualDetector->deleteLater();
+    m_mainWindow->deleteLater();
+    m_camera->deleteLater();
+    m_config->deleteLater();
+}
+
+void TestActualDetector::constructor()
+{
+    QVERIFY(NULL != m_actualDetector->m_mainWindow);
+    QVERIFY(NULL != m_actualDetector->m_config);
+    QVERIFY(NULL != m_actualDetector->camPtr);
+    QVERIFY(m_mainWindow == m_actualDetector->m_mainWindow);
+    QVERIFY(m_config == m_actualDetector->m_config);
+    QVERIFY(m_camera == m_actualDetector->camPtr);
+}
+
+QTEST_MAIN(TestActualDetector)
+
+#include "testactualdetector.moc"

--- a/test/testActualDetector/testActualDetector.pro
+++ b/test/testActualDetector/testActualDetector.pro
@@ -1,0 +1,46 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2016-06-07T11:54:14
+#
+#-------------------------------------------------
+
+QT       += widgets testlib xml network
+
+TARGET = testActualDetector
+CONFIG   += console
+CONFIG   -= app_bundle
+
+TEMPLATE = app
+
+QMAKE_CXXFLAGS += -std=c++11
+
+CONFIG += c++11
+
+DEFINES += SRCDIR=\\\"$$PWD/\\\" \
+    _UNIT_TEST_
+
+include(../../src/opencv.pri)
+
+INCLUDEPATH += . \
+    ../../src \
+    ../mock
+
+SOURCES += \
+    ../../src/actualdetector.cpp \
+    ../mock/mockconfig.cpp \
+    ../mock/mockcamera.cpp \
+    ../mock/mockMainWindow.cpp \
+    ../mock/mockRecorder.cpp \
+    ../mock/mockCTracker.cpp \
+    ../mock/mockDetector.cpp \
+    testActualDetector.cpp
+
+HEADERS += ../../src/actualdetector.h \
+    ../../src/config.h \
+    ../../src/camera.h \
+    ../../src/recorder.h \
+    ../../src/mainwindow.h \
+    ../../src/Ctracker.h \
+    ../../src/Detector.h
+
+

--- a/test/testRecorder/testRecorder.pro
+++ b/test/testRecorder/testRecorder.pro
@@ -22,11 +22,12 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\" \
 include(../../src/opencv.pri)
 
 INCLUDEPATH += . \
-    ../../src
+    ../../src \
+    ../mock
 
 SOURCES += testrecorder.cpp \
-    mockcamera.cpp \
-    mockconfig.cpp \
+    ../mock/mockcamera.cpp \
+    ../mock/mockconfig.cpp \
     ../../src/recorder.cpp \
     ../../src/camerainfo.cpp
 

--- a/test/testRecorder/testrecorder.cpp
+++ b/test/testRecorder/testrecorder.cpp
@@ -7,6 +7,10 @@
 #include <QtTest>
 #include <QString>
 #include <QFile>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+extern cv::Mat mockCameraNextFrame;
 
 /**
  * @brief Unit test of Recorder class
@@ -24,6 +28,7 @@ private Q_SLOTS:
     void cleanupTestCase();
     void constructor();
     void saveResultData();
+    void mockCamera();
 
 private:
     Recorder* m_recorder;
@@ -162,6 +167,59 @@ void TestRecorder::saveResultData() {
     QVERIFY(thumbnailFile.exists());
     QVERIFY(thumbnailFile.remove());
     QVERIFY(!thumbnailFile.exists());
+}
+
+void TestRecorder::mockCamera() {
+    Vec3b pixel;
+    bool showImage = false;     // If you want to see test images, change this to true
+
+    cv::namedWindow("Mock camera frame");
+
+    QVERIFY(m_camera->getWebcamFrame().data == mockCameraNextFrame.data);
+    QVERIFY(mockCameraNextFrame.empty());
+    QVERIFY(m_camera->getWebcamFrame().empty());
+    QVERIFY(0 == mockCameraNextFrame.cols);
+    QVERIFY(0 == mockCameraNextFrame.rows);
+    QVERIFY(0 == m_camera->getWebcamFrame().cols);
+    QVERIFY(0 == m_camera->getWebcamFrame().rows);
+
+    // 1st image
+    mockCameraNextFrame = cv::Mat(m_config->cameraHeight(), m_config->cameraWidth(), CV_8UC3, Scalar(0, 0, 0));
+    cv::rectangle(mockCameraNextFrame, Rect(10, 10, 50, 50), Scalar(40, 60, 80), -1);
+    if (showImage) {
+        cv::imshow("Mock camera frame", mockCameraNextFrame);
+        cv::waitKey(0);
+    }
+    QVERIFY(m_camera->getWebcamFrame().data == mockCameraNextFrame.data);
+    QVERIFY(!mockCameraNextFrame.empty());
+    QVERIFY(!m_camera->getWebcamFrame().empty());
+    QVERIFY(m_config->cameraWidth() == m_camera->getWebcamFrame().cols);
+    QVERIFY(m_config->cameraHeight() == m_camera->getWebcamFrame().rows);
+    pixel = m_camera->getWebcamFrame().at<Vec3b>(Point(10, 10));
+    QVERIFY(40 == pixel[0]);
+    QVERIFY(60 == pixel[1]);
+    QVERIFY(80 == pixel[2]);
+    pixel = m_camera->getWebcamFrame().at<Vec3b>(Point(9, 10));
+    QVERIFY(0 == pixel[0]);
+    QVERIFY(0 == pixel[1]);
+    QVERIFY(0 == pixel[2]);
+
+    // another image
+    mockCameraNextFrame = cv::Mat(m_config->cameraHeight(), m_config->cameraWidth(), CV_8UC3, Scalar(0, 0, 0));
+    cv::rectangle(mockCameraNextFrame, Rect(110, 10, 50, 50), Scalar(90, 70, 50), -1);
+    if (showImage) {
+        cv::imshow("Mock camera frame", mockCameraNextFrame);
+        cv::waitKey(0);
+    }
+    QVERIFY(m_camera->getWebcamFrame().data == mockCameraNextFrame.data);
+    pixel = m_camera->getWebcamFrame().at<Vec3b>(Point(110, 10));
+    QVERIFY(90 == pixel[0]);
+    QVERIFY(70 == pixel[1]);
+    QVERIFY(50 == pixel[2]);
+    pixel = m_camera->getWebcamFrame().at<Vec3b>(Point(109, 10));
+    QVERIFY(0 == pixel[0]);
+    QVERIFY(0 == pixel[1]);
+    QVERIFY(0 == pixel[2]);
 }
 
 QTEST_APPLESS_MAIN(TestRecorder)

--- a/test/testRecorder/testrecorder.cpp
+++ b/test/testRecorder/testrecorder.cpp
@@ -1,3 +1,20 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "recorder.h"
 #include "actualdetector.h"

--- a/test/testRecorder/testrecorder.cpp
+++ b/test/testRecorder/testrecorder.cpp
@@ -45,6 +45,10 @@ private Q_SLOTS:
     void cleanupTestCase();
     void constructor();
     void saveResultData();
+
+    /**
+     * Basic mock Camera test. See a blocking Camera::getWebcamFrame() test in ActualDetector unit test.
+     */
     void mockCamera();
 
 private:

--- a/test/testsuite.pro
+++ b/test/testsuite.pro
@@ -4,5 +4,6 @@ TEMPLATE = subdirs
 SUBDIRS = \
     testConfig \
     testCameraInfo \
-    testRecorder
+    testRecorder \
+    testActualDetector
 


### PR DESCRIPTION
I'm quite happy about the blocking mock Camera::getWebcamFrame() even if I don't know whether it will serve well in real life testing. Anyway now it's possible to start developing detection algorithm tests so that video frames are fed one by one to the detector and the results are checked after each frame.

There are other small stuff in this pull request, too. Video frame access sync fix most probably fixes some crashing (9af9cc3). Accessing non-synced stuff across threads is the quickest way to problems. :) Also it's a nightmare to track down like all thread-related testing.
