### PR TITLE
Automatically checking video codecs (2)

### DIFF
--- a/lang/detector_fi.ts
+++ b/lang/detector_fi.ts
@@ -4,42 +4,42 @@
 <context>
     <name>ActualDetector</name>
     <message>
-        <location filename="../src/actualdetector.cpp" line="120"/>
-        <source>WARNING: could not load cascade classifier</source>
+        <location filename="../src/actualdetector.cpp" line="85"/>
+        <source>WARNING: could not load bird detection data (cascade classifier file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="184"/>
+        <location filename="../src/actualdetector.cpp" line="185"/>
         <source>Positive detection - starting video recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="244"/>
+        <location filename="../src/actualdetector.cpp" line="245"/>
         <source>One object identified as a bird</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="250"/>
+        <location filename="../src/actualdetector.cpp" line="251"/>
         <source>Finished recording - All found objects negative: removed video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="259"/>
+        <location filename="../src/actualdetector.cpp" line="260"/>
         <source>Finished recording - At least one object found positive: saved video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="265"/>
+        <location filename="../src/actualdetector.cpp" line="266"/>
         <source>Finished recording - Minimum required positive detections not met: removed video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="559"/>
+        <location filename="../src/actualdetector.cpp" line="564"/>
         <source>%1 area(s) being ignored in order to filter the moon and stars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="740"/>
+        <location filename="../src/actualdetector.cpp" line="747"/>
         <source>ERROR: Selected area of detection does not match camera resolution. Re-select area of detection.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -47,25 +47,8 @@
 <context>
     <name>CameraResolutionDialog</name>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="26"/>
-        <source>Query supported web camera resolutions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/cameraresolutiondialog.ui" line="46"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="59"/>
-        <source>- Querying the supported web camera resolutions causes problems with some web camera brands. Use at your own risk.</source>
-        <extracomment>Bullet list item</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="78"/>
-        <source>- Recommended to use only vendor-supported resolutions</source>
-        <extracomment>Bullet list item</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -75,18 +58,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="112"/>
-        <source>Query status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/cameraresolutiondialog.ui" line="142"/>
         <source>Available resolutions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/cameraresolutiondialog.ui" line="26"/>
+        <source>Check supported web camera resolutions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cameraresolutiondialog.ui" line="59"/>
+        <source>- Checking the supported web camera resolutions causes problems with some web camera brands.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cameraresolutiondialog.ui" line="78"/>
+        <source>- It is recommended to read your webcam specification or manual for supported resolutions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/cameraresolutiondialog.ui" line="112"/>
+        <source>Checking status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../src/cameraresolutiondialog.ui" line="171"/>
-        <source>&amp;Start querying</source>
+        <source>&amp;Start checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -256,242 +254,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="601"/>
-        <location filename="../src/mainwindow.cpp" line="429"/>
+        <location filename="../src/mainwindow.ui" line="532"/>
+        <location filename="../src/mainwindow.cpp" line="411"/>
         <source>Detection not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="640"/>
+        <location filename="../src/mainwindow.ui" line="571"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Deactivate for better performance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="643"/>
+        <location filename="../src/mainwindow.ui" line="574"/>
         <source>Display webcam during detection (not recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="690"/>
-        <location filename="../src/mainwindow.cpp" line="508"/>
+        <location filename="../src/mainwindow.ui" line="621"/>
+        <location filename="../src/mainwindow.cpp" line="505"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="737"/>
+        <location filename="../src/mainwindow.ui" line="668"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="757"/>
+        <location filename="../src/mainwindow.ui" line="688"/>
         <source>Filter noise by pixel size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="769"/>
-        <location filename="../src/mainwindow.ui" line="853"/>
+        <location filename="../src/mainwindow.ui" line="700"/>
+        <location filename="../src/mainwindow.ui" line="784"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="821"/>
+        <location filename="../src/mainwindow.ui" line="752"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="841"/>
+        <location filename="../src/mainwindow.ui" line="772"/>
         <source>Select threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="885"/>
+        <location filename="../src/mainwindow.ui" line="816"/>
         <source>0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="902"/>
+        <location filename="../src/mainwindow.ui" line="833"/>
         <source>Number of recorded videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="938"/>
-        <location filename="../src/mainwindow.cpp" line="438"/>
+        <location filename="../src/mainwindow.ui" line="869"/>
+        <location filename="../src/mainwindow.cpp" line="420"/>
         <source>Start detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="956"/>
+        <location filename="../src/mainwindow.ui" line="887"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="963"/>
+        <location filename="../src/mainwindow.ui" line="894"/>
         <source>Clear messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="970"/>
+        <location filename="../src/mainwindow.ui" line="901"/>
         <source>Upload images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="980"/>
-        <source>PushButton</source>
+        <location filename="../src/mainwindow.ui" line="911"/>
+        <source>Start rec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="95"/>
+        <location filename="../src/mainwindow.cpp" line="73"/>
         <source>For feedback and bug reports contact the developer at contact@ufoid.net</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="214"/>
-        <location filename="../src/mainwindow.cpp" line="384"/>
+        <location filename="../src/mainwindow.cpp" line="198"/>
+        <location filename="../src/mainwindow.cpp" line="366"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="214"/>
+        <location filename="../src/mainwindow.cpp" line="198"/>
         <source>Playing video file while recording another video is disabled. Wait until the recording has finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="232"/>
+        <location filename="../src/mainwindow.cpp" line="216"/>
         <source>Delete video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="233"/>
-        <source>Do you really want to delete this video?</source>
+        <location filename="../src/mainwindow.cpp" line="217"/>
+        <source>Do you want to permanently delete this video?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="264"/>
+        <location filename="../src/mainwindow.cpp" line="248"/>
         <source>Video list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="265"/>
+        <location filename="../src/mainwindow.cpp" line="249"/>
         <source>Delete selected items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="276"/>
+        <location filename="../src/mainwindow.cpp" line="260"/>
         <source>Delete videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="277"/>
+        <location filename="../src/mainwindow.cpp" line="261"/>
         <source>Do you really want to delete the selected videos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="307"/>
-        <location filename="../src/mainwindow.cpp" line="330"/>
+        <location filename="../src/mainwindow.cpp" line="291"/>
+        <location filename="../src/mainwindow.cpp" line="313"/>
         <source>%1 - Positive: %2 Negative: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="310"/>
+        <location filename="../src/mainwindow.cpp" line="294"/>
         <source>%1 - Positive detections: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="333"/>
+        <location filename="../src/mainwindow.cpp" line="316"/>
         <source>%1 - Negative detections: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
+        <location filename="../src/mainwindow.cpp" line="325"/>
         <source>ERROR: XML file containing the detection area information was not read correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="344"/>
+        <location filename="../src/mainwindow.cpp" line="326"/>
         <source>ERROR: Detection is not working. Select area of detection first in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="384"/>
+        <location filename="../src/mainwindow.cpp" line="366"/>
         <source>Cannot edit settings when detection process is running. Stop the detection process first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="409"/>
-        <source>Detection started on %1</source>
+        <location filename="../src/mainwindow.cpp" line="391"/>
+        <source>Detection started at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="411"/>
+        <location filename="../src/mainwindow.cpp" line="393"/>
         <source>Stop detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="415"/>
+        <location filename="../src/mainwindow.cpp" line="397"/>
         <source>Failed to start detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="550"/>
+        <location filename="../src/mainwindow.cpp" line="542"/>
         <source>Error: Selected webcam resolution is NOT ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="643"/>
+        <location filename="../src/mainwindow.cpp" line="651"/>
         <source>ERROR: Found webcam but video frame could not be read. Reconnect and check resolution in settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="658"/>
-        <location filename="../src/mainwindow.cpp" line="673"/>
-        <source>ERROR: Could not find Raw Video Codec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="659"/>
-        <location filename="../src/mainwindow.cpp" line="674"/>
-        <source>ERROR: Please contact the developer with the information about your system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="685"/>
-        <source>ERROR: Could not find video encoder needed for FFV1 Codec.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="686"/>
-        <source>ERROR: Please install ffmpeg or avconv, or contact the developer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="688"/>
-        <source>Using video encoder %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="698"/>
-        <source>ERROR: Could not find Lagarith Lossless Video Codec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="699"/>
-        <source>ERROR: Download and install from http://lags.leetcode.net/codec.html</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/mainwindow.cpp" line="848"/>
-        <location filename="../src/mainwindow.cpp" line="853"/>
+        <location filename="../src/mainwindow.cpp" line="811"/>
+        <location filename="../src/mainwindow.cpp" line="816"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="848"/>
+        <location filename="../src/mainwindow.cpp" line="811"/>
         <source>Select the pixel size of noise that will be ignored in the detection. 
 Recommended value: 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="853"/>
+        <location filename="../src/mainwindow.cpp" line="816"/>
         <source>Select the threshold filter value that will be used in the motion detection algorithm. 
 Increase the value if clouds are being detected. 
 Recommended value: 10</source>
@@ -506,199 +467,179 @@ Recommended value: 10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="43"/>
+        <location filename="../src/settingsdialog.ui" line="250"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="53"/>
+        <location filename="../src/settingsdialog.ui" line="260"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="65"/>
-        <location filename="../src/settingsdialog.ui" line="79"/>
-        <location filename="../src/settingsdialog.ui" line="257"/>
-        <location filename="../src/settingsdialog.ui" line="344"/>
+        <location filename="../src/settingsdialog.ui" line="88"/>
+        <location filename="../src/settingsdialog.ui" line="189"/>
+        <location filename="../src/settingsdialog.ui" line="196"/>
+        <location filename="../src/settingsdialog.ui" line="210"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="72"/>
+        <location filename="../src/settingsdialog.ui" line="172"/>
         <source>UFOID user token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="89"/>
+        <location filename="../src/settingsdialog.ui" line="47"/>
         <source>Image path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="97"/>
+        <location filename="../src/settingsdialog.ui" line="122"/>
         <source>Webcam 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="102"/>
+        <location filename="../src/settingsdialog.ui" line="127"/>
         <source>Webcam 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="107"/>
+        <location filename="../src/settingsdialog.ui" line="132"/>
         <source>Webcam 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="112"/>
+        <location filename="../src/settingsdialog.ui" line="137"/>
         <source>Webcam 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="120"/>
+        <location filename="../src/settingsdialog.ui" line="152"/>
         <source>Video path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="127"/>
-        <location filename="../src/settingsdialog.ui" line="207"/>
+        <location filename="../src/settingsdialog.ui" line="54"/>
+        <location filename="../src/settingsdialog.ui" line="61"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="134"/>
+        <location filename="../src/settingsdialog.ui" line="312"/>
         <source>Draw rectangle around object in the video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="151"/>
-        <source>Area Status:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settingsdialog.ui" line="175"/>
+        <location filename="../src/settingsdialog.ui" line="289"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="182"/>
+        <location filename="../src/settingsdialog.ui" line="296"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="194"/>
+        <location filename="../src/settingsdialog.ui" line="108"/>
         <source>Save images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="230"/>
+        <location filename="../src/settingsdialog.ui" line="217"/>
         <source>Select webcam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="242"/>
+        <location filename="../src/settingsdialog.ui" line="73"/>
         <source>Minimum required number of positive detections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="265"/>
-        <source>Raw Video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settingsdialog.ui" line="270"/>
-        <source>FFV1 Lossless Video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settingsdialog.ui" line="275"/>
-        <source>Lagarith Lossless Video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/settingsdialog.ui" line="283"/>
+        <location filename="../src/settingsdialog.ui" line="95"/>
         <source>Video codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="290"/>
+        <location filename="../src/settingsdialog.ui" line="145"/>
         <source>Detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="312"/>
+        <location filename="../src/settingsdialog.ui" line="239"/>
         <source>Select detection area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="351"/>
+        <location filename="../src/settingsdialog.ui" line="203"/>
         <source>Select resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="109"/>
-        <location filename="../src/settingsdialog.cpp" line="191"/>
+        <location filename="../src/settingsdialog.cpp" line="118"/>
+        <location filename="../src/settingsdialog.cpp" line="200"/>
         <source>Select Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="132"/>
+        <location filename="../src/settingsdialog.cpp" line="141"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="132"/>
+        <location filename="../src/settingsdialog.cpp" line="141"/>
         <source>Unknown camera aspect ratio. Please change camera width and/or height. Settings are not saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="138"/>
+        <location filename="../src/settingsdialog.cpp" line="147"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="138"/>
+        <location filename="../src/settingsdialog.cpp" line="147"/>
         <source>Settings saved successfully. Restart the application to apply the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="182"/>
+        <location filename="../src/settingsdialog.cpp" line="191"/>
         <source>Select the detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="182"/>
+        <location filename="../src/settingsdialog.cpp" line="191"/>
         <source>XML files (*.xml)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="203"/>
+        <location filename="../src/settingsdialog.cpp" line="212"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="203"/>
+        <location filename="../src/settingsdialog.cpp" line="212"/>
         <source>Restart the application before creating detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="246"/>
+        <location filename="../src/settingsdialog.cpp" line="255"/>
         <source>Codec Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="246"/>
+        <location filename="../src/settingsdialog.cpp" line="255"/>
         <source>Raw Video results is big file sizes. 
 A lossless codec is recommended. 
 Windows 8 users should use the Lagarith Codec.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="251"/>
+        <location filename="../src/settingsdialog.cpp" line="260"/>
         <source>UFOID.net User Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="251"/>
+        <location filename="../src/settingsdialog.cpp" line="260"/>
         <source>Copy the user token from your UFOID account into this field to enable the upload feature. 
 The code can be found at http://ufoid.net/profile/edit</source>
         <translation type="unfinished"></translation>
@@ -724,6 +665,24 @@ The code can be found at http://ufoid.net/profile/edit</source>
     <message>
         <location filename="../src/updateapplicationdialog.cpp" line="28"/>
         <source>New version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VideoCodecSupportInfo</name>
+    <message>
+        <location filename="../src/videocodecsupportinfo.cpp" line="40"/>
+        <source>Raw Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/videocodecsupportinfo.cpp" line="41"/>
+        <source>FFV1 Lossless Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/videocodecsupportinfo.cpp" line="42"/>
+        <source>Lagarith Lossless Video</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/Detector.pro
+++ b/src/Detector.pro
@@ -44,7 +44,8 @@ SOURCES += main.cpp\
     cameraresolutiondialog.cpp \
     videolist.cpp \
     videouploaderdialog.cpp \
-    updateapplicationdialog.cpp
+    updateapplicationdialog.cpp \
+    videocodecsupportinfo.cpp
 
 HEADERS  += \
     recorder.h \
@@ -69,7 +70,8 @@ HEADERS  += \
     cameraresolutiondialog.h \
     videolist.h \
     videouploaderdialog.h \
-    updateapplicationdialog.h
+    updateapplicationdialog.h \
+    videocodecsupportinfo.h
 
 FORMS    += \
     mainwindow.ui \

--- a/src/actualdetector.h
+++ b/src/actualdetector.h
@@ -72,7 +72,7 @@ public:
 #ifndef _UNIT_TEST_
 private:
 #endif
-    Recorder* theRecorder;
+    Recorder* m_recorder;
     Camera* camPtr;
     Config* m_config;
     MainWindow* m_mainWindow;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -67,24 +67,24 @@ Config::Config(QObject *parent) : QObject(parent)
     m_defaultDetectionDataDir = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) +"/.UFO ID";
 #endif
 
+    m_videoCodecSupportInfo = new VideoCodecSupportInfo(m_defaultVideoEncoderLocation);
+    m_videoCodecSupportInfo->init();
+
     m_defaultResultDataFileName = m_defaultDetectionDataDir + "/logs.xml";
     m_defaultResultDocumentDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)+"/UFO ID";
     m_defaultDetectionAreaFileName = m_defaultDetectionDataDir + "/detectionArea.xml";
 
     m_defaultResultVideoDir = m_defaultResultDocumentDir + "/Videos";
     if ((QSysInfo::windowsVersion()==QSysInfo::WV_WINDOWS8) || (QSysInfo::windowsVersion()==QSysInfo::WV_WINDOWS8_1)) {
-        m_defaultVideoCodec = 2;
+        m_defaultVideoCodecStr = "LAGS";
     } else {
-        m_defaultVideoCodec = 1;
+        m_defaultVideoCodecStr = "FFV1";
     }
     m_defaultResultVideoWithRectangles = false;
     m_defaultResultImageDir = m_defaultResultDocumentDir + "/Images";
     m_defaultSaveResultImages = false;
 
     m_defaultUserTokenAtUfoId = "";
-
-    m_videoCodecSupportInfo = new VideoCodecSupportInfo(m_defaultVideoEncoderLocation);
-    m_videoCodecSupportInfo->init();
 }
 
 Config::~Config() {
@@ -143,8 +143,12 @@ QString Config::resultVideoDir() {
     return m_settings->value(m_settingKeys[Config::ResultVideoDir], m_defaultResultVideoDir).toString();
 }
 
+QString Config::resultVideoCodecStr() {
+    return m_settings->value(m_settingKeys[Config::ResultVideoCodec], m_defaultVideoCodecStr).toString();
+}
+
 int Config::resultVideoCodec() {
-    return m_settings->value(m_settingKeys[Config::ResultVideoCodec], m_defaultVideoCodec).toInt();
+    return m_videoCodecSupportInfo->stringToFourcc(this->resultVideoCodecStr());
 }
 
 bool Config::resultVideoWithObjectRectangles() {
@@ -241,7 +245,7 @@ void Config::setResultVideoDir(QString dirName) {
     emit settingsChanged();
 }
 
-void Config::setResultVideoCodec(int codec) {
+void Config::setResultVideoCodec(QString codec) {
     m_settings->setValue(m_settingKeys[Config::ResultVideoCodec], QVariant(codec));
     m_settings->sync();
     emit settingsChanged();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -82,6 +82,13 @@ Config::Config(QObject *parent) : QObject(parent)
     m_defaultSaveResultImages = false;
 
     m_defaultUserTokenAtUfoId = "";
+
+    m_videoCodecSupportInfo = new VideoCodecSupportInfo(m_defaultVideoEncoderLocation);
+    m_videoCodecSupportInfo->init();
+}
+
+Config::~Config() {
+    m_videoCodecSupportInfo->deleteLater();
 }
 
 QString Config::applicationVersion() {
@@ -162,6 +169,10 @@ int Config::detectionAreaSize() {
 
 QString Config::userTokenAtUfoId() {
     return m_settings->value(m_settingKeys[Config::UserTokenAtUfoId], m_defaultUserTokenAtUfoId).toString();
+}
+
+VideoCodecSupportInfo* Config::videoCodecSupportInfo() {
+    return m_videoCodecSupportInfo;
 }
 
 void Config::setApplicationVersion(QString version) {

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#include "videocodecsupportinfo.h"
 #include <QObject>
 #include <QSettings>
 #include <QApplication>
@@ -61,6 +62,8 @@ public:
     };
 
     explicit Config(QObject *parent = 0);
+
+    ~Config();
 
     /**
      * @brief applicationVersion Application version number
@@ -176,6 +179,8 @@ public:
      * @return
      */
     QString userTokenAtUfoId();
+
+    VideoCodecSupportInfo* videoCodecSupportInfo();
 
     /**
      * @brief setApplicationVersion set application version. Format: major.minor.subminor
@@ -305,6 +310,8 @@ private:
     bool m_defaultSaveResultImages;     ///< whether to save result images by default
 
     QString m_defaultUserTokenAtUfoId;  ///< default user token for ufoid.net: empty value by default
+
+    VideoCodecSupportInfo* m_videoCodecSupportInfo; ///< info about video codec support
 
 signals:
     /**

--- a/src/config.h
+++ b/src/config.h
@@ -144,9 +144,16 @@ public:
     QString resultVideoDir();
 
     /**
-     * @brief resultVideoCodec result video codec
-     * 0: raw video, 1: lossless FFV1, 2: lossless Lagarith
-     * @return
+     * @brief Get result video codec.
+     *
+     * @return FOURCC code of the codec as string
+     */
+    QString resultVideoCodecStr();
+
+    /**
+     * @brief Get result video codec.
+     *
+     * @return FOURCC code of the codec
      */
     int resultVideoCodec();
 
@@ -248,10 +255,10 @@ public:
     void setResultVideoDir(QString dirName);
 
     /**
-     * @brief setResultVideoCodec set result video codec
-     * @param codec
+     * @brief Set result video codec.
+     * @param codec FOURCC code of the codec as string
      */
-    void setResultVideoCodec(int codec);
+    void setResultVideoCodec(QString codec);
 
     /**
      * @brief setResultVideoWithObjectRectangles set whether to draw rectangles around objects in result videos
@@ -303,7 +310,7 @@ private:
     QString m_defaultResultDataFileName; ///< default file name for result data file (result database)
     QString m_defaultResultDocumentDir; ///< default root directory for result images and videos
     QString m_defaultResultVideoDir;    ///< default directory for result videos
-    int m_defaultVideoCodec;
+    QString m_defaultVideoCodecStr;        ///< default video codec as FOURCC string
     bool m_defaultResultVideoWithRectangles; ///< whether to draw rectanges into result video
     QString m_defaultVideoEncoderLocation;
     QString m_defaultResultImageDir;    ///< default directory for result images

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -40,7 +40,6 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     m_cameraViewResolution = Size(width, height);
     const int NOISELEVEL = m_config->noiseFilterPixelSize();
     QString VERSION = m_config->applicationVersion();
-    const int codec = m_config->resultVideoCodec();
 
     if ((VERSION == "") || (VERSION < m_programVersion))
     {
@@ -73,7 +72,7 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     ui->progressBar->hide();
     ui->outputText->append(tr("For feedback and bug reports contact the developer at contact@ufoid.net"));
 
-    if (checkCameraAndCodec(width, height, codec))
+    if (checkCamera(width, height))
     {
         threadWebcam.reset(new std::thread(&MainWindow::updateWebcamFrame, this));
     }
@@ -634,10 +633,7 @@ void MainWindow::checkDetectionAreaFile()
     }
 }
 
-/*
- * Check camera and codec
- */
-bool MainWindow::checkCameraAndCodec(const int width, const int height, const int codec)
+bool MainWindow::checkCamera(const int width, const int height)
 {
     bool success = false;
     if (checkAndSetResolution(width, height) && !threadWebcam && m_camera->isWebcamOpen())
@@ -645,7 +641,7 @@ bool MainWindow::checkCameraAndCodec(const int width, const int height, const in
         try
         {
             m_webcamFrame = m_camera->getWebcamFrame();
-            cv::resize(m_webcamFrame,m_webcamFrame, m_cameraViewResolution,0, 0, INTER_CUBIC);
+            cv::resize(m_webcamFrame, m_webcamFrame, m_cameraViewResolution, 0, 0, INTER_CUBIC);
             success = true;
         }
         catch( cv::Exception& e )
@@ -658,64 +654,6 @@ bool MainWindow::checkCameraAndCodec(const int width, const int height, const in
     else if (!m_camera->isWebcamOpen())
     {
         ui->outputText->append("ERROR: Could not open webcam. Select webcam in settings");
-    }
-
-
-    if (codec==0)
-    {
-        VideoWriter theVideoWriter;
-        theVideoWriter.open("filename.avi", 0, 25, Size(width, height), true);
-        if (!theVideoWriter.isOpened())
-        {
-            ui->outputText->append(tr("ERROR: Could not find Raw Video Codec"));
-            ui->outputText->append(tr("ERROR: Please contact the developer with the information about your system"));
-        }
-        else
-        {
-            theVideoWriter.release();
-            remove("filename.avi");
-        }
-    }
-    else if (codec==1)
-    {
-        VideoWriter theVideoWriter;
-        theVideoWriter.open("filename.avi",0, 25, Size(width, height), true);
-        if (!theVideoWriter.isOpened())
-        {
-            ui->outputText->append(tr("ERROR: Could not find Raw Video Codec"));
-            ui->outputText->append(tr("ERROR: Please contact the developer with the information about your system"));
-        }
-        else
-        {
-            theVideoWriter.release();
-            remove("filename.avi");
-        }
-
-        QFile ffmpegFile(m_config->videoEncoderLocation());
-        if(!ffmpegFile.exists())
-        {
-            ui->outputText->append(tr("ERROR: Could not find video encoder needed for FFV1 Codec."));
-            ui->outputText->append(tr("ERROR: Please install ffmpeg or avconv, or contact the developer."));
-        } else {
-            ui->outputText->append(tr("Using video encoder %1").arg(m_config->videoEncoderLocation()));
-        }
-
-    }
-    else if (codec==2)
-    {
-        VideoWriter theVideoWriter;
-        theVideoWriter.open("filename.avi",CV_FOURCC('L','A','G','S'), 25, Size(width, height), true);
-        if (!theVideoWriter.isOpened())
-        {
-            ui->outputText->append(tr("ERROR: Could not find Lagarith Lossless Video Codec"));
-            ui->outputText->append(tr("ERROR: Download and install from http://lags.leetcode.net/codec.html"));
-        }
-        else
-        {
-            theVideoWriter.release();
-            remove("filename.avi");
-        }
-
     }
 
     ui->startButton->setEnabled(success);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -63,6 +63,11 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     m_detectionStatusStyleOn = "color: #55FF55;";
     m_detectionStatusStyleOff = "color: #FF5555;";
 
+#if defined(Q_OS_WINDOWS)
+    VideoCodecSupportInfo* codecInfo = m_config->videoCodecSupportInfo();
+    codecInfo->removeSupport(CV_FOURCC('F', 'F', 'V', '1'), VideoCodecSupportInfo::OpenCv);
+#endif
+
     checkFolders();
     readLogFileAndGetRootElement();
     checkDetectionAreaFile();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -121,16 +121,13 @@ private:
     void checkDetectionAreaFile();
 
     /**
-     * @brief checkCameraAndCodec
-     *
-     * @todo refactor to checkCamera() and checkCodec()  (cleaner code)
+     * @brief Verify camera is working normally.
      *
      * @param width
      * @param height
-     * @param codec
      * @return
      */
-    bool checkCameraAndCodec(const int width, const int height, const int codec);
+    bool checkCamera(const int width, const int height);
 
     /**
      * Check that the folder for the images and videos exist

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -56,8 +56,20 @@ Recorder::Recorder(Camera *cameraPtr, Config *configPtr) :
     }
     else if (m_codecSetting == 0 || m_codecSetting == 1)
     {
+        // if requesting FFV1 codec use default codec and use ffmpeg/avconv to convert
         m_videoCodec = DEFAULT_CODEC;
     }
+    /*switch (m_codecSetting) {
+        case 0:
+            m_videoCodec = CV_FOURCC('I', 'Y', 'U', 'V');
+            break;
+        case 1:
+            m_videoCodec = CV_FOURCC('F', 'F', 'V', '1');
+            break;
+        case 2:
+            m_videoCodec = CV_FOURCC('L', 'A', 'G', 'S');
+            break;
+    }*/
 
     reloadResultDataFile();
     m_recording = false;

--- a/src/recorder.h
+++ b/src/recorder.h
@@ -99,9 +99,6 @@ private:
 
     std::chrono::high_resolution_clock::time_point prevTime, currentTime;
 
-    int m_videoCodec;
-    int m_codecSetting;
-
     void recordThread();
     void readFrameThread();
 
@@ -120,13 +117,13 @@ public slots:
 private slots:
 #endif
     /**
-     * @brief Creates a new QProcess that encodes the temporary raw video to FFV1 with ffmpeg/avconv
+     * @brief Creates a new QProcess that encodes the temporary raw video with ffmpeg/avconv
      *
      * @note this method NEEDS to be called via signal-slot system, I guess in order
      * to run it in the main thread. If this is called from detecting thread via direct
      * method call then can't get signals from the encoder process.
      */
-    void startEncodingVideoToFFV1(QString tempVideoFileName, QString targetVideoFileName);
+    void startEncodingVideo(QString tempVideoFileName, QString targetVideoFileName);
 
     void onVideoEncodingFinished();
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -57,7 +57,17 @@ SettingsDialog::SettingsDialog(QWidget *parent, Camera *camPtr, Config *configPt
     ui->lineImagePath->setText(m_config->resultImageDir());
     ui->lineMinPosRequired->setText(QString::number(m_config->minPositiveDetections()));
 
-    ui->comboBoxCodec->setCurrentIndex(m_config->resultVideoCodec());
+    VideoCodecSupportInfo* codecInfo = m_config->videoCodecSupportInfo();
+    QListIterator<int> supportedCodecsIt(codecInfo->supportedCodecs());
+    while (supportedCodecsIt.hasNext()) {
+        int codec = supportedCodecsIt.next();
+        ui->comboBoxCodec->addItem(codecInfo->codecName(codec), QVariant(codecInfo->fourccToString(codec)));
+    }
+    ui->comboBoxCodec->setCurrentIndex(ui->comboBoxCodec->findData(
+        QVariant(m_config->resultVideoCodecStr())));
+    if (ui->comboBoxCodec->currentIndex() < 0) {
+        ui->comboBoxCodec->setCurrentIndex(0);
+    }
     setWindowFlags(Qt::FramelessWindowHint);
     setWindowFlags(Qt::WindowTitleHint);
     m_detectionAreaDialogIsOpen=false;
@@ -78,7 +88,7 @@ void SettingsDialog::saveSettings()
     m_config->setResultImageDir(ui->lineImagePath->text());
     m_config->setResultVideoWithObjectRectangles(ui->checkBoxRectangle->isChecked());
     m_config->setMinPositiveDetections(ui->lineMinPosRequired->text().toInt());
-    m_config->setResultVideoCodec(ui->comboBoxCodec->currentIndex());
+    m_config->setResultVideoCodec(ui->comboBoxCodec->currentData().toString());
     m_config->setUserTokenAtUfoId(ui->lineToken->text());
 }
 

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -97,23 +97,7 @@
      </widget>
     </item>
     <item row="2" column="1">
-     <widget class="QComboBox" name="comboBoxCodec">
-      <item>
-       <property name="text">
-        <string>Raw Video</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>FFV1 Lossless Video</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>Lagarith Lossless Video</string>
-       </property>
-      </item>
-     </widget>
+     <widget class="QComboBox" name="comboBoxCodec"/>
     </item>
     <item row="7" column="0" colspan="2">
      <widget class="QCheckBox" name="checkBoxsaveImages">

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -16,13 +16,19 @@ VideoCodecSupportInfo::VideoCodecSupportInfo(QString externalVideoEncoderLocatio
     m_fourccToEncoderStr.insert(toFourcc("LAGS"), "lagarith");
 }
 
-void VideoCodecSupportInfo::init() {
+bool VideoCodecSupportInfo::init() {
     if (m_isInitialized) {
-        return;
+        return false;
     }
     int codec = 0;
     QListIterator<int> codecIt(m_codecSupport.keys());
     QList<int> encoderList;
+    QFile encoder(m_videoEncoderLocation);
+
+    if (!encoder.exists()) {
+        qDebug() << "Video encoder" << m_videoEncoderLocation << "doesn't exist";
+        return false;
+    }
 
     while (codecIt.hasNext()) {
         codec = codecIt.next();
@@ -38,6 +44,7 @@ void VideoCodecSupportInfo::init() {
         }
     }
     m_isInitialized = true;
+    return true;
 }
 
 bool VideoCodecSupportInfo::isInitialized() {

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -25,19 +25,21 @@ VideoCodecSupportInfo::VideoCodecSupportInfo(QString externalVideoEncoderLocatio
     m_testFileName = "dummy_Wa8F7bVL3lmF4ngfD0894u32Nd.avi";
     m_isInitialized = false;
 
-    m_codecSupport.insert(toFourcc("IYUV"), QList<int>());
-    m_codecSupport.insert(toFourcc("FFV1"), QList<int>());
-    m_codecSupport.insert(toFourcc("LAGS"), QList<int>());
+    m_rawVideoCodecStr = "IYUV";
+
+    m_codecSupport.insert(stringToFourcc(m_rawVideoCodecStr), QList<int>());
+    m_codecSupport.insert(stringToFourcc("FFV1"), QList<int>());
+    m_codecSupport.insert(stringToFourcc("LAGS"), QList<int>());
 
     // These codes are used by external encoder (ffmpeg/avconv). Use parameter -codecs for list.
-    m_fourccToEncoderStr.insert(toFourcc("IYUV"), "rawvideo");
-    m_fourccToEncoderStr.insert(toFourcc("FFV1"), "ffv1");
-    m_fourccToEncoderStr.insert(toFourcc("LAGS"), "lagarith");
+    m_fourccToEncoderStr.insert(stringToFourcc(m_rawVideoCodecStr), "rawvideo");
+    m_fourccToEncoderStr.insert(stringToFourcc("FFV1"), "ffv1");
+    m_fourccToEncoderStr.insert(stringToFourcc("LAGS"), "lagarith");
 
     // These names are shown to the user for codec selection
-    m_fourccToCodecName.insert(toFourcc("IYUV"), tr("Raw Video"));
-    m_fourccToCodecName.insert(toFourcc("FFV1"), tr("FFV1 Lossless Video"));
-    m_fourccToCodecName.insert(toFourcc("LAGS"), tr("Lagarith Lossless Video"));
+    m_fourccToCodecName.insert(stringToFourcc(m_rawVideoCodecStr), tr("Raw Video"));
+    m_fourccToCodecName.insert(stringToFourcc("FFV1"), tr("FFV1 Lossless Video"));
+    m_fourccToCodecName.insert(stringToFourcc("LAGS"), tr("Lagarith Lossless Video"));
 }
 
 bool VideoCodecSupportInfo::init() {
@@ -69,10 +71,20 @@ bool VideoCodecSupportInfo::isInitialized() {
     return m_isInitialized;
 }
 
-// static
-int VideoCodecSupportInfo::toFourcc(QString fourccStr) {
+int VideoCodecSupportInfo::stringToFourcc(QString fourccStr) {
+    if (fourccStr.length() != 4) {
+        return 0;
+    }
     char* str = fourccStr.toLocal8Bit().data();
     return CV_FOURCC(str[0], str[1], str[2], str[3]);
+}
+
+QString VideoCodecSupportInfo::fourccToString(int fourcc) {
+    QString str;
+    for (int i = 0; i < 4; i++) {
+        str.append(QChar((char)((fourcc >> i*8) & 0xff)));
+    }
+    return str;
 }
 
 bool VideoCodecSupportInfo::isOpencvSupported(int fourcc) {
@@ -99,6 +111,14 @@ QList<int> VideoCodecSupportInfo::supportedCodecs() {
 
 QString VideoCodecSupportInfo::codecName(int fourcc) {
     return m_fourccToCodecName.value(fourcc, "");
+}
+
+QString VideoCodecSupportInfo::fourccToEncoderString(int fourcc) {
+    return m_fourccToEncoderStr.value(fourcc, "");
+}
+
+QString VideoCodecSupportInfo::rawVideoCodecStr() {
+    return m_rawVideoCodecStr;
 }
 
 bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -49,6 +49,20 @@ bool VideoCodecSupportInfo::isEncoderSupported(int fourcc) {
     return m_codecSupport.value(fourcc).contains(VideoCodecSupportInfo::Encoder);
 }
 
+QList<int> VideoCodecSupportInfo::supportedCodecs() {
+    QList<int> codecs;
+    QListIterator<int> codecIt(m_codecSupport.keys());
+    int codec = 0;
+
+    while (codecIt.hasNext()) {
+        codec = codecIt.next();
+        if (!m_codecSupport.value(codec).isEmpty()) {
+            codecs << codec;
+        }
+    }
+    return codecs;
+}
+
 bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {
     cv::VideoWriter writer;
     cv::Mat frame;

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -1,3 +1,21 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "videocodecsupportinfo.h"
 
 VideoCodecSupportInfo::VideoCodecSupportInfo(QString externalVideoEncoderLocation, QObject* parent)

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -29,9 +29,15 @@ VideoCodecSupportInfo::VideoCodecSupportInfo(QString externalVideoEncoderLocatio
     m_codecSupport.insert(toFourcc("FFV1"), QList<int>());
     m_codecSupport.insert(toFourcc("LAGS"), QList<int>());
 
+    // These codes are used by external encoder (ffmpeg/avconv). Use parameter -codecs for list.
     m_fourccToEncoderStr.insert(toFourcc("IYUV"), "rawvideo");
     m_fourccToEncoderStr.insert(toFourcc("FFV1"), "ffv1");
     m_fourccToEncoderStr.insert(toFourcc("LAGS"), "lagarith");
+
+    // These names are shown to the user for codec selection
+    m_fourccToCodecName.insert(toFourcc("IYUV"), tr("Raw Video"));
+    m_fourccToCodecName.insert(toFourcc("FFV1"), tr("FFV1 Lossless Video"));
+    m_fourccToCodecName.insert(toFourcc("LAGS"), tr("Lagarith Lossless Video"));
 }
 
 bool VideoCodecSupportInfo::init() {
@@ -89,6 +95,10 @@ QList<int> VideoCodecSupportInfo::supportedCodecs() {
         }
     }
     return codecs;
+}
+
+QString VideoCodecSupportInfo::codecName(int fourcc) {
+    return m_fourccToCodecName.value(fourcc, "");
 }
 
 bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -23,12 +23,6 @@ bool VideoCodecSupportInfo::init() {
     int codec = 0;
     QListIterator<int> codecIt(m_codecSupport.keys());
     QList<int> encoderList;
-    QFile encoder(m_videoEncoderLocation);
-
-    if (!encoder.exists()) {
-        qDebug() << "Video encoder" << m_videoEncoderLocation << "doesn't exist";
-        return false;
-    }
 
     while (codecIt.hasNext()) {
         codec = codecIt.next();

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -16,6 +16,23 @@ VideoCodecSupportInfo::VideoCodecSupportInfo(Config* config, QObject* parent)
 }
 
 void VideoCodecSupportInfo::init() {
+    int codec = 0;
+    QListIterator<int> codecIt(m_codecSupport.keys());
+    QList<int> encoderList;
+
+    while (codecIt.hasNext()) {
+        codec = codecIt.next();
+        if (testOpencvSupport(codec)) {
+            encoderList = m_codecSupport.value(codec);
+            encoderList.append(VideoCodecSupportInfo::OpenCv);
+            m_codecSupport.insert(codec, encoderList);
+        }
+        if (testEncoderSupport(codec)) {
+            encoderList = m_codecSupport.value(codec);
+            encoderList.append(VideoCodecSupportInfo::Encoder);
+            m_codecSupport.insert(codec, encoderList);
+        }
+    }
 }
 
 // static
@@ -25,23 +42,11 @@ int VideoCodecSupportInfo::toFourcc(QString fourccStr) {
 }
 
 bool VideoCodecSupportInfo::isOpencvSupported(int fourcc) {
-    Q_UNUSED(fourcc);
-    return false;
-}
-
-bool VideoCodecSupportInfo::isOpencvSupported(QString fourccStr) {
-    Q_UNUSED(fourccStr);
-    return false;
+    return m_codecSupport.value(fourcc).contains(VideoCodecSupportInfo::OpenCv);
 }
 
 bool VideoCodecSupportInfo::isEncoderSupported(int fourcc) {
-    Q_UNUSED(fourcc);
-    return false;
-}
-
-bool VideoCodecSupportInfo::isEncoderSupported(QString fourccStr) {
-    Q_UNUSED(fourccStr);
-    return false;
+    return m_codecSupport.value(fourcc).contains(VideoCodecSupportInfo::Encoder);
 }
 
 bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -121,6 +121,14 @@ QString VideoCodecSupportInfo::rawVideoCodecStr() {
     return m_rawVideoCodecStr;
 }
 
+void VideoCodecSupportInfo::removeSupport(int fourcc, int encoder) {
+    if (m_codecSupport.keys().contains(fourcc)) {
+        QList<int> supportList = m_codecSupport.value(fourcc);
+        supportList.removeAll(encoder);
+        m_codecSupport.insert(fourcc, supportList);
+    }
+}
+
 bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {
     cv::VideoWriter writer;
     cv::Mat frame;

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -1,0 +1,106 @@
+#include "videocodecsupportinfo.h"
+
+VideoCodecSupportInfo::VideoCodecSupportInfo(Config* config, QObject* parent)
+    : QObject(parent)
+{
+    m_config = config;
+    m_testFileName = "dummy_Wa8F7bVL3lmF4ngfD0894u32Nd.avi";
+
+    m_codecSupport.insert(toFourcc("IYUV"), QList<int>());
+    m_codecSupport.insert(toFourcc("FFV1"), QList<int>());
+    m_codecSupport.insert(toFourcc("LAGS"), QList<int>());
+
+    m_fourccToEncoderStr.insert(toFourcc("IYUV"), "rawvideo");
+    m_fourccToEncoderStr.insert(toFourcc("FFV1"), "ffv1");
+    m_fourccToEncoderStr.insert(toFourcc("LAGS"), "lagarith");
+}
+
+void VideoCodecSupportInfo::init() {
+}
+
+// static
+int VideoCodecSupportInfo::toFourcc(QString fourccStr) {
+    char* str = fourccStr.toLocal8Bit().data();
+    return CV_FOURCC(str[0], str[1], str[2], str[3]);
+}
+
+bool VideoCodecSupportInfo::isOpencvSupported(int fourcc) {
+    Q_UNUSED(fourcc);
+    return false;
+}
+
+bool VideoCodecSupportInfo::isOpencvSupported(QString fourccStr) {
+    Q_UNUSED(fourccStr);
+    return false;
+}
+
+bool VideoCodecSupportInfo::isEncoderSupported(int fourcc) {
+    Q_UNUSED(fourcc);
+    return false;
+}
+
+bool VideoCodecSupportInfo::isEncoderSupported(QString fourccStr) {
+    Q_UNUSED(fourccStr);
+    return false;
+}
+
+bool VideoCodecSupportInfo::testOpencvSupport(int fourcc) {
+    cv::VideoWriter writer;
+    cv::Mat frame;
+    bool supported = false;
+    int writtenFourcc = 0;
+    std::string testFileNameStd(m_testFileName.toLocal8Bit().data());
+
+    // try opening & writing file
+    if (!writer.open(testFileNameStd, fourcc, 25, cv::Size(m_config->cameraWidth(), m_config->cameraHeight()))) {
+        return false;
+    }
+    if (!writer.isOpened()) {
+        return false;
+    }
+    frame = cv::Mat(m_config->cameraHeight(), m_config->cameraWidth(), CV_8UC3);
+    writer.write(frame);
+    writer.release();
+
+    // check result
+    cv::VideoCapture reader;
+    if (!reader.open(testFileNameStd)) {
+        return false;
+    }
+    writtenFourcc = (int)reader.get(CV_CAP_PROP_FOURCC);
+    if (writtenFourcc == fourcc) {
+        supported = true;
+    }
+    QFile testFile(m_testFileName);
+    testFile.remove();
+    return supported;
+}
+
+bool VideoCodecSupportInfo::testEncoderSupport(int fourcc) {
+    QProcess encoder;
+    QStringList encoderOutput;
+    QStringList args;
+    QString encoderCodecStr = m_fourccToEncoderStr.value(fourcc);
+
+    if (encoderCodecStr.isEmpty()) {
+        return false;
+    }
+
+    args << "-codecs";
+    encoder.start(m_config->videoEncoderLocation(), args);
+    encoder.waitForFinished();
+    while (encoder.canReadLine()) {
+        encoderOutput << encoder.readLine();
+    }
+    QStringListIterator listIt(encoderOutput);
+    while (listIt.hasNext()) {
+        QString line = listIt.next();
+        // Find encoder name and verify it can encode videos.
+        QRegExp regex("^.EV...\\ " + encoderCodecStr + ".*$");
+        if (regex.exactMatch(line)) {
+            return true;
+        }
+    }
+    return false;
+}
+

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -181,7 +181,7 @@ bool VideoCodecSupportInfo::testEncoderSupport(int fourcc) {
     while (listIt.hasNext()) {
         QString line = listIt.next();
         // Find encoder name and verify it can encode videos.
-        QRegExp regex("^.EV...\\ " + encoderCodecStr + ".*$");
+        QRegExp regex("^ *.EV...\\ " + encoderCodecStr + ".*$");
         if (regex.exactMatch(line)) {
             return true;
         }

--- a/src/videocodecsupportinfo.cpp
+++ b/src/videocodecsupportinfo.cpp
@@ -181,8 +181,8 @@ bool VideoCodecSupportInfo::testEncoderSupport(int fourcc) {
     while (listIt.hasNext()) {
         QString line = listIt.next();
         // Find encoder name and verify it can encode videos.
-        QRegExp regex("^ *.EV...\\ " + encoderCodecStr + ".*$");
-        if (regex.exactMatch(line)) {
+        QRegularExpression regex("^ *.EV...\\ " + encoderCodecStr + ".*$");
+        if (regex.match(line).hasMatch()) {
             return true;
         }
     }

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -117,6 +117,13 @@ public:
      */
     QString rawVideoCodecStr();
 
+    /**
+     * @brief Remove encoder support for codec.
+     * @param fourcc
+     * @param encoder
+     */
+    void removeSupport(int fourcc, int encoder);
+
 #ifndef _UNIT_TEST_
 private:
 #endif

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -5,6 +5,7 @@
 #include <QProcess>
 #include <QHash>
 #include <QFile>
+#include <QDebug>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
@@ -37,7 +38,7 @@ public:
     /**
      * @brief This method does the work for actually collecting info about supported codecs.
      */
-    void init();
+    bool init();
 
     /**
      * @brief Whether this object is initialized.

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -21,6 +21,7 @@
 
 #include <QObject>
 #include <QProcess>
+#include <QMap>
 #include <QHash>
 #include <QFile>
 #include <QDebug>
@@ -68,7 +69,14 @@ public:
      * @param fourccStr FOURCC code as string
      * @return FOURCC code
      */
-    static int toFourcc(QString fourccStr);
+    int stringToFourcc(QString fourccStr);
+
+    /**
+     * @brief Convert FOURCC code to FOURCC string.
+     * @param fourcc
+     * @return
+     */
+    QString fourccToString(int fourcc);
 
     /**
      * @brief Whether OpenCV supports the specified codec.
@@ -96,16 +104,31 @@ public:
      */
     QString codecName(int fourcc);
 
+    /**
+     * @brief Convert FOURCC code to string used by external encoder.
+     * @param fourcc FOURCC code of the codec
+     * @return Codec string used by external encoder
+     */
+    QString fourccToEncoderString(int fourcc);
+
+    /**
+     * @brief Shortcut to get raw video codec string
+     * @return raw video codec as FOURCC string ("IYUV")
+     */
+    QString rawVideoCodecStr();
+
 #ifndef _UNIT_TEST_
 private:
 #endif
     QString m_videoEncoderLocation; ///< video encoder executable location
     bool m_isInitialized;           ///< object initialized
-    QHash<int, QList<int>> m_codecSupport;      ///< encoder fourcc -> support provider list
+    /// @todo table model would be clearer. Columns: fourcc, encoderStr, codecName, encoderList
+    QMap<int, QList<int>> m_codecSupport;      ///< encoder fourcc -> support provider list
     QHash<int, QString> m_fourccToEncoderStr;   ///< encoder fourcc -> encoder ID string used by encoder
     QHash<int, QString> m_fourccToCodecName;    ///< clear text name of codec (max. few words)
 
     QString m_testFileName;     ///< file name used in support tests -- @todo must not collide with existing files
+    QString m_rawVideoCodecStr; ///< raw video codec FOURCC string
 
     /**
      * @brief Test whether OpenCV supports the specified codec.

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -56,6 +56,11 @@ public:
      */
     bool isEncoderSupported(int fourcc);
 
+    /**
+     * @brief List of codecs with some kind of support. Codecs are listed as FOURCC codes.
+     */
+    QList<int> supportedCodecs();
+
 #ifndef _UNIT_TEST_
 private:
 #endif

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -1,0 +1,103 @@
+#ifndef VIDEOCODECSUPPORTINFO_H
+#define VIDEOCODECSUPPORTINFO_H
+
+#include "config.h"
+#include <QObject>
+#include <QProcess>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+
+/**
+ * @brief Support info about video codecs.
+ *
+ * @see http://www.fourcc.org/codecs.php
+ */
+class VideoCodecSupportInfo : public QObject
+{
+    Q_OBJECT
+public:
+
+    /**
+     * @brief Support providers.
+     * @note Encoder executable location is specified in the settings (Config class).
+     */
+    enum SupportProviders {
+        OpenCv = 0,
+        Encoder,
+        SUPPORT_PROVIDER_COUNT
+    };
+
+    explicit VideoCodecSupportInfo(Config* config, QObject *parent = 0);
+
+    /**
+     * @brief This method does the work for actually collecting info about supported codecs.
+     */
+    void init();
+
+    /**
+     * @brief Convert FOURCC string to FOURCC code.
+     * @param fourccStr FOURCC code as string
+     * @return FOURCC code
+     */
+    static int toFourcc(QString fourccStr);
+
+    QStringList codecStrList();
+
+    /**
+     * @brief Whether OpenCV supports the specified codec.
+     * @param fourcc FOURCC code for codec
+     * @return true: codec supported, false: not supported
+     */
+    bool isOpencvSupported(int fourcc);
+
+    /**
+     * @brief Whether OpenCV supports the specified codec.
+     * @param fourccStr FOURCC code for codec
+     * @return true: codec supported, false: not supported
+     */
+    bool isOpencvSupported(QString fourccStr);
+
+    /**
+     * @brief Whether the video encoder supports the specified codec.
+     * @param fourcc FOURCC code for codec
+     * @return true: codec supported, false: not supported
+     */
+    bool isEncoderSupported(int fourcc);
+
+    /**
+     * @brief Whether the video encoder supports the specified codec.
+     * @param fourccStr FOURCC code for codec
+     * @return true: codec supported, false: not supported
+     */
+    bool isEncoderSupported(QString fourccStr);
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+    Config* m_config;
+    QHash<int, QList<int>> m_codecSupport;  ///< encoder fourcc -> support provider list
+    QMap<int, QString> m_fourccToEncoderStr;    ///< encoder fourcc -> encoder ID string used by encoder
+
+    QString m_testFileName;     ///< file name used in support tests -- @todo must not collide with existing files
+
+    /**
+     * @brief Test whether OpenCV supports the specified codec.
+     * @param fourcc FOURCC code for codec
+     * @return
+     */
+    bool testOpencvSupport(int fourcc);
+
+    /**
+     * @brief Test whether the video encoder supports the specified codec.
+     * @param fourccStr FOURCC code for codec
+     * @return true: codec supported, false: not supported
+     */
+    bool testEncoderSupport(int fourcc);
+
+signals:
+
+public slots:
+};
+
+#endif // VIDEOCODECSUPPORTINFO_H

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -89,13 +89,21 @@ public:
      */
     QList<int> supportedCodecs();
 
+    /**
+     * @brief Name of codec to be shown to user
+     * @param fourcc FOURCC code of the codec
+     * @return codec name
+     */
+    QString codecName(int fourcc);
+
 #ifndef _UNIT_TEST_
 private:
 #endif
     QString m_videoEncoderLocation; ///< video encoder executable location
     bool m_isInitialized;           ///< object initialized
     QHash<int, QList<int>> m_codecSupport;      ///< encoder fourcc -> support provider list
-    QHash<int, QString> m_fourccToEncoderStr;    ///< encoder fourcc -> encoder ID string used by encoder
+    QHash<int, QString> m_fourccToEncoderStr;   ///< encoder fourcc -> encoder ID string used by encoder
+    QHash<int, QString> m_fourccToCodecName;    ///< clear text name of codec (max. few words)
 
     QString m_testFileName;     ///< file name used in support tests -- @todo must not collide with existing files
 

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -42,8 +42,6 @@ public:
      */
     static int toFourcc(QString fourccStr);
 
-    QStringList codecStrList();
-
     /**
      * @brief Whether OpenCV supports the specified codec.
      * @param fourcc FOURCC code for codec
@@ -52,25 +50,11 @@ public:
     bool isOpencvSupported(int fourcc);
 
     /**
-     * @brief Whether OpenCV supports the specified codec.
-     * @param fourccStr FOURCC code for codec
-     * @return true: codec supported, false: not supported
-     */
-    bool isOpencvSupported(QString fourccStr);
-
-    /**
      * @brief Whether the video encoder supports the specified codec.
      * @param fourcc FOURCC code for codec
      * @return true: codec supported, false: not supported
      */
     bool isEncoderSupported(int fourcc);
-
-    /**
-     * @brief Whether the video encoder supports the specified codec.
-     * @param fourccStr FOURCC code for codec
-     * @return true: codec supported, false: not supported
-     */
-    bool isEncoderSupported(QString fourccStr);
 
 #ifndef _UNIT_TEST_
 private:

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -1,12 +1,12 @@
 #ifndef VIDEOCODECSUPPORTINFO_H
 #define VIDEOCODECSUPPORTINFO_H
 
-#include "config.h"
 #include <QObject>
 #include <QProcess>
+#include <QHash>
+#include <QFile>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-
 
 /**
  * @brief Support info about video codecs.
@@ -19,21 +19,30 @@ class VideoCodecSupportInfo : public QObject
 public:
 
     /**
-     * @brief Support providers.
-     * @note Encoder executable location is specified in the settings (Config class).
+     * @brief Video encoders.
      */
-    enum SupportProviders {
-        OpenCv = 0,
-        Encoder,
-        SUPPORT_PROVIDER_COUNT
+    enum VideoEncoders {
+        OpenCv = 0,     ///< OpenCV internal encoder (might be same as external, in fact)
+        External,       ///< External encoder (ffmpeg/avconv). Executable location specified in settings (Config class)
+        VIDEO_ENCODER_COUNT
     };
 
-    explicit VideoCodecSupportInfo(Config* config, QObject *parent = 0);
+    /**
+     * @brief VideoCodecSupportInfo constructor.
+     * @param externalVideoEncoderLocation full path to external video encoder
+     * @param parent
+     */
+    explicit VideoCodecSupportInfo(QString externalVideoEncoderLocation, QObject *parent = 0);
 
     /**
      * @brief This method does the work for actually collecting info about supported codecs.
      */
     void init();
+
+    /**
+     * @brief Whether this object is initialized.
+     */
+    bool isInitialized();
 
     /**
      * @brief Convert FOURCC string to FOURCC code.
@@ -64,9 +73,10 @@ public:
 #ifndef _UNIT_TEST_
 private:
 #endif
-    Config* m_config;
-    QHash<int, QList<int>> m_codecSupport;  ///< encoder fourcc -> support provider list
-    QMap<int, QString> m_fourccToEncoderStr;    ///< encoder fourcc -> encoder ID string used by encoder
+    QString m_videoEncoderLocation; ///< video encoder executable location
+    bool m_isInitialized;           ///< object initialized
+    QHash<int, QList<int>> m_codecSupport;      ///< encoder fourcc -> support provider list
+    QHash<int, QString> m_fourccToEncoderStr;    ///< encoder fourcc -> encoder ID string used by encoder
 
     QString m_testFileName;     ///< file name used in support tests -- @todo must not collide with existing files
 

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -1,3 +1,21 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef VIDEOCODECSUPPORTINFO_H
 #define VIDEOCODECSUPPORTINFO_H
 

--- a/src/videocodecsupportinfo.h
+++ b/src/videocodecsupportinfo.h
@@ -25,6 +25,7 @@
 #include <QHash>
 #include <QFile>
 #include <QDebug>
+#include <QRegularExpression>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 

--- a/test/mock/mockRecorder.cpp
+++ b/test/mock/mockRecorder.cpp
@@ -18,6 +18,10 @@
 
 #include "recorder.h"
 
+int mockRecorderStartCount;
+int mockRecorderStopCount;
+
+
 Recorder::Recorder(Camera* cameraPtr, Config* configPtr) {
     Q_UNUSED(cameraPtr);
     Q_UNUSED(configPtr);
@@ -25,10 +29,14 @@ Recorder::Recorder(Camera* cameraPtr, Config* configPtr) {
 
 void Recorder::startRecording(cv::Mat &firstFrame) {
     Q_UNUSED(firstFrame);
+    m_recording = true;
+    mockRecorderStartCount++;
 }
 
 void Recorder::stopRecording(bool willSaveVideo) {
     Q_UNUSED(willSaveVideo);
+    m_recording = false;
+    mockRecorderStopCount++;
 }
 
 void Recorder::setRectangle(cv::Rect &r, bool isRed) {

--- a/test/mock/mockRecorder.cpp
+++ b/test/mock/mockRecorder.cpp
@@ -39,7 +39,7 @@ void Recorder::setRectangle(cv::Rect &r, bool isRed) {
 void Recorder::reloadResultDataFile() {
 }
 
-void Recorder::startEncodingVideoToFFV1(QString tempVideoFileName, QString targetVideoFileName) {
+void Recorder::startEncodingVideo(QString tempVideoFileName, QString targetVideoFileName) {
     Q_UNUSED(tempVideoFileName);
     Q_UNUSED(targetVideoFileName);
 }

--- a/test/mock/mockVideoCodecSupportInfo.cpp
+++ b/test/mock/mockVideoCodecSupportInfo.cpp
@@ -34,10 +34,14 @@ bool VideoCodecSupportInfo::isInitialized() {
     return m_isInitialized;
 }
 
-// static
-int VideoCodecSupportInfo::toFourcc(QString fourccStr) {
-    Q_UNUSED(fourccStr);
-    return 0;
+int VideoCodecSupportInfo::stringToFourcc(QString fourccStr) {
+    char* str = fourccStr.toLocal8Bit().data();
+    return CV_FOURCC(str[0], str[1], str[2], str[3]);
+}
+
+QString VideoCodecSupportInfo::fourccToString(int fourcc) {
+    Q_UNUSED(fourcc);
+    return "";
 }
 
 bool VideoCodecSupportInfo::isOpencvSupported(int fourcc) {
@@ -58,5 +62,14 @@ QList<int> VideoCodecSupportInfo::supportedCodecs() {
 QString VideoCodecSupportInfo::codecName(int fourcc) {
     Q_UNUSED(fourcc);
     return "";
+}
+
+QString VideoCodecSupportInfo::fourccToEncoderString(int fourcc) {
+    Q_UNUSED(fourcc);
+    return "";
+}
+
+QString VideoCodecSupportInfo::rawVideoCodecStr() {
+    return "IYUV";
 }
 

--- a/test/mock/mockVideoCodecSupportInfo.cpp
+++ b/test/mock/mockVideoCodecSupportInfo.cpp
@@ -55,3 +55,8 @@ QList<int> VideoCodecSupportInfo::supportedCodecs() {
     return list;
 }
 
+QString VideoCodecSupportInfo::codecName(int fourcc) {
+    Q_UNUSED(fourcc);
+    return "";
+}
+

--- a/test/mock/mockVideoCodecSupportInfo.cpp
+++ b/test/mock/mockVideoCodecSupportInfo.cpp
@@ -1,0 +1,57 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "videocodecsupportinfo.h"
+
+VideoCodecSupportInfo::VideoCodecSupportInfo(QString externalVideoEncoderLocation, QObject *parent)
+    : QObject(parent)
+{
+    m_videoEncoderLocation = externalVideoEncoderLocation;
+    m_isInitialized = false;
+}
+
+bool VideoCodecSupportInfo::init() {
+    m_isInitialized = true;
+    return true;
+}
+
+bool VideoCodecSupportInfo::isInitialized() {
+    return m_isInitialized;
+}
+
+// static
+int VideoCodecSupportInfo::toFourcc(QString fourccStr) {
+    Q_UNUSED(fourccStr);
+    return 0;
+}
+
+bool VideoCodecSupportInfo::isOpencvSupported(int fourcc) {
+    Q_UNUSED(fourcc);
+    return false;
+}
+
+bool VideoCodecSupportInfo::isEncoderSupported(int fourcc) {
+    Q_UNUSED(fourcc);
+    return false;
+}
+
+QList<int> VideoCodecSupportInfo::supportedCodecs() {
+    QList<int> list;
+    return list;
+}
+

--- a/test/mock/mockcamera.cpp
+++ b/test/mock/mockcamera.cpp
@@ -95,8 +95,10 @@ void Camera::release() {
 
 cv::Mat Camera::getWebcamFrame() {
     if (mockCamera_blockFrameEnabled) {
+        //qDebug() << "lock mutex";
         mockCamera_blockerMutex.lock();
         mockCamera_blockerCond.wait(mockCamera_blockerMutex);
+        //qDebug() << "unlock mutex";
         mockCamera_blockerMutex.unlock();
     }
     return mockCameraNextFrame;

--- a/test/mock/mockconfig.cpp
+++ b/test/mock/mockconfig.cpp
@@ -19,9 +19,11 @@
 #include "config.h"
 
 QString mockConfigResultDataDir;
+int mockConfigResultVideoCodec;
 
 Config::Config(QObject *parent) {
     Q_UNUSED(parent);
+    mockConfigResultVideoCodec = 0;
 }
 
 QString Config::applicationVersion() {
@@ -81,7 +83,7 @@ QString Config::resultVideoDir() {
 }
 
 int Config::resultVideoCodec() {
-    return 0;
+    return mockConfigResultVideoCodec;
 }
 
 bool Config::resultVideoWithObjectRectangles() {
@@ -148,7 +150,7 @@ void Config::setResultVideoDir(QString dirName) {
 }
 
 void Config::setResultVideoCodec(int codec) {
-    Q_UNUSED(codec);
+    mockConfigResultVideoCodec = codec;
 }
 
 void Config::setResultVideoWithObjectRectangles(bool drawRectangles) {

--- a/test/mock/mockconfig.cpp
+++ b/test/mock/mockconfig.cpp
@@ -17,13 +17,28 @@
  */
 
 #include "config.h"
+#include <QTest>
 
 QString mockConfigResultDataDir;
 int mockConfigResultVideoCodec;
+QString mockConfigResultVideoCodecStr;
 
 Config::Config(QObject *parent) {
     Q_UNUSED(parent);
     mockConfigResultVideoCodec = 0;
+    mockConfigResultVideoCodecStr = "";
+    QString encoderLocation = "";
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+    encoderLocation = "/usr/bin/avconv";
+#elif defined(Q_OS_WIN)
+    encoderLocation = QCoreApplication::applicationDirPath()+"/ffmpeg.exe";
+#endif
+    QVERIFY(!encoderLocation.isEmpty());
+    m_videoCodecSupportInfo = new VideoCodecSupportInfo(encoderLocation);
+    m_videoCodecSupportInfo->init();
+}
+
+Config::~Config() {
 }
 
 QString Config::applicationVersion() {
@@ -80,6 +95,10 @@ QString Config::resultDataFile() {
 
 QString Config::resultVideoDir() {
     return "./videos";
+}
+
+QString Config::resultVideoCodecStr() {
+    return mockConfigResultVideoCodecStr;
 }
 
 int Config::resultVideoCodec() {
@@ -153,8 +172,8 @@ void Config::setResultVideoDir(QString dirName) {
     Q_UNUSED(dirName);
 }
 
-void Config::setResultVideoCodec(int codec) {
-    mockConfigResultVideoCodec = codec;
+void Config::setResultVideoCodec(QString codec) {
+    mockConfigResultVideoCodecStr = codec;
 }
 
 void Config::setResultVideoWithObjectRectangles(bool drawRectangles) {

--- a/test/mock/mockconfig.cpp
+++ b/test/mock/mockconfig.cpp
@@ -70,7 +70,7 @@ QString Config::detectionAreaFile() {
 }
 
 int Config::detectionAreaSize() {
-    return 10000;
+    return this->cameraWidth() * this->cameraHeight();
 }
 
 int Config::noiseFilterPixelSize() {

--- a/test/mock/mockconfig.cpp
+++ b/test/mock/mockconfig.cpp
@@ -106,6 +106,10 @@ QString Config::userTokenAtUfoId() {
     return "";
 }
 
+VideoCodecSupportInfo* Config::videoCodecSupportInfo() {
+    return m_videoCodecSupportInfo;
+}
+
 void Config::setApplicationVersion(QString version) {
     Q_UNUSED(version);
 }

--- a/test/testActualDetector/testActualDetector.pro
+++ b/test/testActualDetector/testActualDetector.pro
@@ -33,6 +33,7 @@ SOURCES += \
     ../mock/mockRecorder.cpp \
     ../mock/mockCTracker.cpp \
     ../mock/mockDetector.cpp \
+    ../mock/mockVideoCodecSupportInfo.cpp \
     testActualDetector.cpp
 
 HEADERS += ../../src/actualdetector.h \
@@ -41,6 +42,7 @@ HEADERS += ../../src/actualdetector.h \
     ../../src/recorder.h \
     ../../src/mainwindow.h \
     ../../src/Ctracker.h \
-    ../../src/Detector.h
+    ../../src/Detector.h \
+    ../../src/videocodecsupportinfo.h
 
 

--- a/test/testActualDetector/testActualDetector.pro
+++ b/test/testActualDetector/testActualDetector.pro
@@ -31,8 +31,12 @@ SOURCES += \
     ../mock/mockcamera.cpp \
     ../mock/mockMainWindow.cpp \
     ../mock/mockRecorder.cpp \
-    ../mock/mockCTracker.cpp \
-    ../mock/mockDetector.cpp \
+    ../../src/Ctracker.cpp \
+    ../../src/Detector.cpp \
+    ../../src/Kalman.cpp \
+    ../../src/HungarianAlg.cpp \
+    ../../src/BackgroundSubtract.cpp \
+    ../../src/VIBE.cpp \
     ../mock/mockVideoCodecSupportInfo.cpp \
     testActualDetector.cpp
 
@@ -43,6 +47,10 @@ HEADERS += ../../src/actualdetector.h \
     ../../src/mainwindow.h \
     ../../src/Ctracker.h \
     ../../src/Detector.h \
+    ../../src/Kalman.h \
+    ../../src/HungarianAlg.h \
+    ../../src/BackgroundSubtract.h \
+    ../../src/VIBE.h \
     ../../src/videocodecsupportinfo.h
 
 

--- a/test/testConfig/testConfig.pro
+++ b/test/testConfig/testConfig.pro
@@ -16,9 +16,16 @@ TEMPLATE = app
 
 DEFINES += _UNIT_TEST_
 
-INCLUDEPATH += ../../src
+include(../../src/opencv.pri)
+
+INCLUDEPATH += ../../src \
+    ../mock
 
 SOURCES += testconfig.cpp \
-    ../../src/config.cpp
-HEADERS += ../../src/config.h
+    ../../src/config.cpp \
+    ../mock/mockVideoCodecSupportInfo.cpp
+
+HEADERS += ../../src/config.h \
+    ../../src/videocodecsupportinfo.h
+
 DEFINES += SRCDIR=\\\"$$PWD/\\\"

--- a/test/testConfig/testconfig.cpp
+++ b/test/testConfig/testconfig.cpp
@@ -12,8 +12,9 @@ public:
 private Q_SLOTS:
     void init();
     void cleanup();
-    void testDefaultValues();
-    void testMotionThreshold();
+    void defaultValues();
+    void motionThreshold();
+    void videoCodecSupportInfo();
 
 private:
     Config* m_config;
@@ -42,7 +43,7 @@ void TestConfig::cleanup() {
     m_config = NULL;
 }
 
-void TestConfig::testDefaultValues() {
+void TestConfig::defaultValues() {
     QVERIFY(m_config->applicationVersion() == "");
     QVERIFY(m_config->checkApplicationUpdates() == true);
 
@@ -70,7 +71,7 @@ void TestConfig::testDefaultValues() {
     QVERIFY(m_config->userTokenAtUfoId() == "");
 }
 
-void TestConfig::testMotionThreshold() {
+void TestConfig::motionThreshold() {
     QFile settingsFile;
     QVERIFY("motionThreshold" == m_config->m_settingKeys[Config::MotionThreshold]);
     QVERIFY(!m_config->m_settings->contains(m_config->m_settingKeys[Config::MotionThreshold]));
@@ -83,6 +84,11 @@ void TestConfig::testMotionThreshold() {
     QVERIFY(settingsFile.exists());
 }
 
-QTEST_APPLESS_MAIN(TestConfig)
+void TestConfig::videoCodecSupportInfo() {
+    QVERIFY(m_config->videoCodecSupportInfo() != NULL);
+    QVERIFY(m_config->videoCodecSupportInfo()->isInitialized());
+}
+
+QTEST_MAIN(TestConfig)
 
 #include "testconfig.moc"

--- a/test/testConfig/testconfig.cpp
+++ b/test/testConfig/testconfig.cpp
@@ -62,7 +62,8 @@ void TestConfig::defaultValues() {
 
     //QVERIFY(m_config->resultDataFile());
     //QVERIFY(m_config->resultVideoDir());
-    QVERIFY(m_config->resultVideoCodec() == 1);
+    QVERIFY(m_config->resultVideoCodecStr() == "FFV1");
+    //QCOMPARE(m_config->resultVideoCodec(), CV_FOURCC('F', 'F', 'V', '1'));
     QVERIFY(m_config->resultVideoWithObjectRectangles() == false);
     //QVERIFY(m_config->videoEncoderLocation());
     //QVERIFY(m_config->resultImageDir());

--- a/test/testRecorder/testRecorder.pro
+++ b/test/testRecorder/testRecorder.pro
@@ -28,11 +28,13 @@ INCLUDEPATH += . \
 SOURCES += testrecorder.cpp \
     ../mock/mockcamera.cpp \
     ../mock/mockconfig.cpp \
+    ../../src/videocodecsupportinfo.cpp \
     ../../src/recorder.cpp \
     ../../src/camerainfo.cpp
 
 HEADERS += ../../src/recorder.h \
     ../../src/config.h \
+    ../../src/videocodecsupportinfo.h \
     ../../src/camera.h \
     ../../src/camerainfo.h
 

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -55,8 +55,6 @@ private:
     int m_frameHeight;
     bool localTestOpencvSupport(int fourcc);
     bool localTestEncoderSupport(QString encoderCodecStr);
-
-private slots:
     void fillExpectedCodecs();
 };
 
@@ -65,22 +63,22 @@ TestVideoCodecSupportInfo::TestVideoCodecSupportInfo()
     m_codecInfo = NULL;
     m_testFileName = "dummy.avi";
     m_videoEncoderLocation = "";
+    m_frameWidth = 640;
+    m_frameHeight = 480;
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_videoEncoderLocation = "/usr/bin/avconv";
 #elif defined(Q_OS_WIN)
     m_videoEncoderLocation = QCoreApplication::applicationDirPath()+"/ffmpeg.exe";
 #endif
-    QVERIFY(!m_videoEncoderLocation.isEmpty());
-    QFile encoderExecutable(m_videoEncoderLocation);
-    QVERIFY(encoderExecutable.exists());
-    m_frameWidth = 640;
-    m_frameHeight = 480;
-    fillExpectedCodecs();
 }
 
 void TestVideoCodecSupportInfo::initTestCase() {
+    QVERIFY(!m_videoEncoderLocation.isEmpty());
+    QFile encoderExecutable(m_videoEncoderLocation);
+    QVERIFY(encoderExecutable.exists());
     m_codecInfo = new VideoCodecSupportInfo(m_videoEncoderLocation);
     QVERIFY(NULL != m_codecInfo);
+    fillExpectedCodecs();
 }
 
 void TestVideoCodecSupportInfo::cleanupTestCase() {

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -203,9 +203,21 @@ void TestVideoCodecSupportInfo::initialize() {
         }
     }
 
+    // case: nonexisting encoder
+
+    QVERIFY(!m_codecInfo->m_isInitialized);
+    QString nonexistingEncoderLocation = "/nonexistingEncoderDir/nonexistingEncoderBin";
+    QFile nonexistingEncoder(nonexistingEncoderLocation);
+    QVERIFY(!nonexistingEncoder.exists());
+    m_codecInfo->m_videoEncoderLocation = nonexistingEncoderLocation;
+    QVERIFY(!m_codecInfo->init());
     QVERIFY(!m_codecInfo->m_isInitialized);
     QVERIFY(!m_codecInfo->isInitialized());
-    m_codecInfo->init();
+
+    // case: existing encoder
+
+    m_codecInfo->m_videoEncoderLocation = m_videoEncoderLocation;
+    QVERIFY(m_codecInfo->init());
     QVERIFY(m_codecInfo->m_isInitialized);
     QVERIFY(m_codecInfo->isInitialized());
 

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -41,6 +41,8 @@ private Q_SLOTS:
     void initialize();  // init() would be called for each test case
     void isSupportedMethods();
     void codecName();
+    void toFromFourcc();
+    void rawVideoCodecStr();
 
 private:
     VideoCodecSupportInfo* m_codecInfo;
@@ -59,8 +61,10 @@ TestVideoCodecSupportInfo::TestVideoCodecSupportInfo()
     m_videoEncoderLocation = "";
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     m_videoEncoderLocation = "/usr/bin/avconv";
+#elif defined(Q_OS_WIN)
+    m_videoEncoderLocation = QCoreApplication::applicationDirPath()+"/ffmpeg.exe";
 #endif
-    QVERIFY(m_videoEncoderLocation != "");
+    QVERIFY(!m_videoEncoderLocation.isEmpty());
     m_frameWidth = 640;
     m_frameHeight = 480;
 }
@@ -318,6 +322,26 @@ void TestVideoCodecSupportInfo::codecName() {
 
     // case: non-existing codec
     QCOMPARE(m_codecInfo->codecName(CV_FOURCC('!', '!', '!', '!')), QString(""));
+}
+
+void TestVideoCodecSupportInfo::toFromFourcc() {
+    QCOMPARE(m_codecInfo->stringToFourcc("IYUV"), CV_FOURCC('I', 'Y', 'U', 'V'));
+    QCOMPARE(m_codecInfo->stringToFourcc("FFV1"), CV_FOURCC('F', 'F', 'V', '1'));
+    QCOMPARE(m_codecInfo->stringToFourcc("LAGS"), CV_FOURCC('L', 'A', 'G', 'S'));
+    QCOMPARE(m_codecInfo->stringToFourcc("1"), 0);
+
+    QCOMPARE(m_codecInfo->fourccToString(CV_FOURCC('I', 'Y', 'U', 'V')), QString("IYUV"));
+    QCOMPARE(m_codecInfo->fourccToString(CV_FOURCC('F', 'F', 'V', '1')), QString("FFV1"));
+    QCOMPARE(m_codecInfo->fourccToString(CV_FOURCC('L', 'A', 'G', 'S')), QString("LAGS"));
+    //QCOMPARE(VideoCodecSupportInfo::fourccToString(0), QString(""));
+
+    QCOMPARE(m_codecInfo->fourccToEncoderString(CV_FOURCC('I', 'Y', 'U', 'V')), QString("rawvideo"));
+    QCOMPARE(m_codecInfo->fourccToEncoderString(CV_FOURCC('F', 'F', 'V', '1')), QString("ffv1"));
+    QCOMPARE(m_codecInfo->fourccToEncoderString(CV_FOURCC('L', 'A', 'G', 'S')), QString("lagarith"));
+}
+
+void TestVideoCodecSupportInfo::rawVideoCodecStr() {
+    QCOMPARE(m_codecInfo->rawVideoCodecStr(), QString("IYUV"));
 }
 
 

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -66,7 +66,7 @@ TestVideoCodecSupportInfo::TestVideoCodecSupportInfo()
     m_frameWidth = 640;
     m_frameHeight = 480;
 #if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
-    m_videoEncoderLocation = "/usr/bin/avconv";
+    m_videoEncoderLocation = "/usr/bin/ffmpeg";
 #elif defined(Q_OS_WIN)
     m_videoEncoderLocation = QCoreApplication::applicationDirPath()+"/ffmpeg.exe";
 #endif
@@ -195,7 +195,7 @@ bool TestVideoCodecSupportInfo::localTestEncoderSupport(QString encoderCodecStr)
         QString line = listIt.next();
         // Find encoder name and verify it can encode videos (E = encode, V = video).
         // Check the output of avconv/ffmpeg -codecs for more info.
-        QRegExp regex("^.EV...\\ " + encoderCodecStr + ".*$");
+        QRegExp regex("^ *.EV...\\ " + encoderCodecStr + ".*$");
         if (regex.exactMatch(line)) {
             //qDebug() << "Found:" << line;
             return true;

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -1,0 +1,164 @@
+
+#include "videocodecsupportinfo.h"
+#include <QString>
+#include <QtTest>
+#include <QRegExp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+extern int mockConfigResultVideoCodec;
+
+class TestVideoCodecSupportInfo : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestVideoCodecSupportInfo();
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+    void constructor();
+    void testOpencvSupport();
+    void testEncoderSupport();
+
+private:
+    Config* m_config;
+    VideoCodecSupportInfo* m_codecInfo;
+    QString m_testFileName;
+    bool localTestOpencvSupport(int fourcc);
+    bool localTestEncoderSupport(QString encoderCodecStr);
+};
+
+TestVideoCodecSupportInfo::TestVideoCodecSupportInfo()
+{
+    m_config = NULL;
+    m_codecInfo = NULL;
+    m_testFileName = "dummy.avi";
+}
+
+void TestVideoCodecSupportInfo::initTestCase() {
+    m_config = new Config();
+    QVERIFY(NULL != m_config);
+    m_codecInfo = new VideoCodecSupportInfo(m_config);
+    QVERIFY(NULL != m_codecInfo);
+}
+
+void TestVideoCodecSupportInfo::cleanupTestCase() {
+    m_codecInfo->deleteLater();
+    m_config->deleteLater();
+}
+
+void TestVideoCodecSupportInfo::constructor() {
+    QVERIFY(m_config == m_codecInfo->m_config);
+}
+
+bool TestVideoCodecSupportInfo::localTestOpencvSupport(int fourcc) {
+    cv::VideoWriter writer;
+    cv::Mat frame;
+    bool supported = false;
+    int writtenFourcc = 0;
+    std::string testFileNameStd(m_testFileName.toLocal8Bit().data());
+
+    // try opening & writing file
+    if (!writer.open(testFileNameStd, fourcc, 25, cv::Size(m_config->cameraWidth(), m_config->cameraHeight()))) {
+        return false;
+    }
+    if (!writer.isOpened()) {
+        return false;
+    }
+    frame = cv::Mat(m_config->cameraHeight(), m_config->cameraWidth(), CV_8UC3);
+    writer.write(frame);
+    writer.release();
+
+    // check result
+    cv::VideoCapture reader;
+    reader.open(testFileNameStd);
+    if (!reader.isOpened()) {
+        return false;
+    }
+    writtenFourcc = (int)reader.get(CV_CAP_PROP_FOURCC);
+    if (writtenFourcc == fourcc) {
+        supported = true;
+    }
+    QFile testFile(m_testFileName);
+    testFile.remove();
+    return supported;
+}
+
+void TestVideoCodecSupportInfo::testOpencvSupport() {
+    int rawFourcc = CV_FOURCC('I', 'Y', 'U', 'V');
+    int ffv1Fourcc = CV_FOURCC('F', 'F', 'V', '1');
+    int lagarithFourcc = CV_FOURCC('L', 'A', 'G', 'S');
+    bool rawSupported = localTestOpencvSupport(rawFourcc);
+    bool ffv1Supported = localTestOpencvSupport(ffv1Fourcc);
+    bool lagarithSupported = localTestOpencvSupport(lagarithFourcc);
+
+    QCOMPARE(m_codecInfo->testOpencvSupport(rawFourcc), rawSupported);
+    QCOMPARE(m_codecInfo->testOpencvSupport(ffv1Fourcc), ffv1Supported);
+    QCOMPARE(m_codecInfo->testOpencvSupport(lagarithFourcc), lagarithSupported);
+
+    // These apply to basic/non-PPA OpenCV2 packages in Ubuntu 14.04.4 (Trusty)
+    QVERIFY(rawSupported);
+    QVERIFY(!ffv1Supported);
+    QVERIFY(!lagarithSupported);
+}
+
+bool TestVideoCodecSupportInfo::localTestEncoderSupport(QString encoderCodecStr) {
+    QProcess encoder;
+    QStringList encoderOutput;
+    QStringList args;
+    args << "-codecs";
+    encoder.start(m_config->videoEncoderLocation(), args);
+    encoder.waitForFinished();
+    while (encoder.canReadLine()) {
+        encoderOutput << encoder.readLine();
+    }
+    QStringListIterator listIt(encoderOutput);
+    while (listIt.hasNext()) {
+        QString line = listIt.next();
+        // Find encoder name and verify it can encode videos (E = encode, V = video).
+        // Check the output of avconv/ffmpeg -codecs for more info.
+        QRegExp regex("^.EV...\\ " + encoderCodecStr + ".*$");
+        if (regex.exactMatch(line)) {
+            qDebug() << "Found:" << line;
+            return true;
+        }
+    }
+    return false;
+}
+
+void TestVideoCodecSupportInfo::testEncoderSupport() {
+    qint64 startTime;
+    qint64 endTime;
+    qint64 difference;
+    int rawFourcc = CV_FOURCC('I', 'Y', 'U', 'V');
+    int ffv1Fourcc = CV_FOURCC('F', 'F', 'V', '1');
+    int lagarithFourcc = CV_FOURCC('L', 'A', 'G', 'S');
+
+    startTime = QDateTime::currentMSecsSinceEpoch();
+    bool rawSupported = localTestEncoderSupport("rawvideo");
+    bool ffv1Supported = localTestEncoderSupport("ffv1");
+    bool lagarithSupported = localTestEncoderSupport("lagarith");
+    endTime = QDateTime::currentMSecsSinceEpoch();
+    difference = endTime - startTime;
+    qDebug() << "Checking encoder support status inside test took" << difference << "ms";
+
+
+    startTime = QDateTime::currentMSecsSinceEpoch();
+    QCOMPARE(m_codecInfo->testEncoderSupport(rawFourcc), rawSupported);
+    QCOMPARE(m_codecInfo->testEncoderSupport(ffv1Fourcc), ffv1Supported);
+    QCOMPARE(m_codecInfo->testEncoderSupport(lagarithFourcc), lagarithSupported);
+    endTime = QDateTime::currentMSecsSinceEpoch();
+    difference = endTime - startTime;
+    qDebug() << "Checking encoder support status by VideoCodecSupportInfo took" << difference << "ms";
+
+    // These apply to basic/non-PPA OpenCV2 packages in Ubuntu 14.04.4 (Trusty)
+    QVERIFY(rawFourcc);
+    QVERIFY(ffv1Supported);
+    QVERIFY(!lagarithSupported);
+}
+
+QTEST_MAIN(TestVideoCodecSupportInfo)
+
+#include "testVideoCodecSupportInfo.moc"

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -97,22 +97,31 @@ void TestVideoCodecSupportInfo::fillExpectedCodecs() {
     m_expectedEncoderStrings[CV_FOURCC('L', 'A', 'G', 'S')] = "lagarith";
 
     int codec = 0;
+    QString codecStr;
     QListIterator<int> codecIt(m_expectedCodecs.keys());
     codecIt.toFront();
+    qDebug() << "Codec support";
     while (codecIt.hasNext()) {
         codec = codecIt.next();
+        codecStr = m_expectedEncoderStrings[codec];
         QList<int> encoderList;
         if (localTestOpencvSupport(codec)) {
             encoderList = m_expectedCodecs.value(codec);
             encoderList.append(VideoCodecSupportInfo::OpenCv);
             m_expectedCodecs.insert(codec, encoderList);
             QVERIFY(m_expectedCodecs.value(codec).contains(VideoCodecSupportInfo::OpenCv));
+            qDebug() << codecStr << "in OpenCV: yes";
+        } else {
+            qDebug() << codecStr << "in OpenCV: no";
         }
         if (localTestEncoderSupport(m_expectedEncoderStrings.value(codec))) {
             encoderList = m_expectedCodecs.value(codec);
             encoderList.append(VideoCodecSupportInfo::External);
             m_expectedCodecs.insert(codec, encoderList);
             QVERIFY(m_expectedCodecs.value(codec).contains(VideoCodecSupportInfo::External));
+            qDebug() << codecStr << "in ffmpeg/avconv: yes";
+        } else {
+            qDebug() << codecStr << "in ffmpeg/avconv: no";
         }
     }
 }

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -71,6 +71,8 @@ TestVideoCodecSupportInfo::TestVideoCodecSupportInfo()
     m_videoEncoderLocation = QCoreApplication::applicationDirPath()+"/ffmpeg.exe";
 #endif
     QVERIFY(!m_videoEncoderLocation.isEmpty());
+    QFile encoderExecutable(m_videoEncoderLocation);
+    QVERIFY(encoderExecutable.exists());
     m_frameWidth = 640;
     m_frameHeight = 480;
     fillExpectedCodecs();

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -262,6 +262,12 @@ void TestVideoCodecSupportInfo::isSupportedMethods() {
         bool expectedEncoderSupported = codecSupport.value(codec).contains(VideoCodecSupportInfo::Encoder);
         bool actualEncoderSupported = m_codecInfo->isEncoderSupported(codec);
         QCOMPARE(actualEncoderSupported, expectedEncoderSupported);
+
+        if (expectedOpencvSupported || expectedEncoderSupported) {
+            QVERIFY(m_codecInfo->supportedCodecs().contains(codec));
+        } else {
+            QVERIFY(!m_codecInfo->supportedCodecs().contains(codec));
+        }
     }
 }
 

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -1,3 +1,20 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "videocodecsupportinfo.h"
 #include <QString>

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -40,6 +40,7 @@ private Q_SLOTS:
     void testEncoderSupport();
     void initialize();  // init() would be called for each test case
     void isSupportedMethods();
+    void codecName();
 
 private:
     VideoCodecSupportInfo* m_codecInfo;
@@ -309,6 +310,16 @@ void TestVideoCodecSupportInfo::isSupportedMethods() {
         }
     }
 }
+
+void TestVideoCodecSupportInfo::codecName() {
+    QCOMPARE(m_codecInfo->codecName(CV_FOURCC('I', 'Y', 'U', 'V')), QString("Raw Video"));
+    QCOMPARE(m_codecInfo->codecName(CV_FOURCC('F', 'F', 'V', '1')), QString("FFV1 Lossless Video"));
+    QCOMPARE(m_codecInfo->codecName(CV_FOURCC('L', 'A', 'G', 'S')), QString("Lagarith Lossless Video"));
+
+    // case: non-existing codec
+    QCOMPARE(m_codecInfo->codecName(CV_FOURCC('!', '!', '!', '!')), QString(""));
+}
+
 
 QTEST_MAIN(TestVideoCodecSupportInfo)
 

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.cpp
@@ -152,6 +152,7 @@ void TestVideoCodecSupportInfo::testEncoderSupport() {
     difference = endTime - startTime;
     qDebug() << "Checking encoder support status inside test took" << difference << "ms";
 
+    // case: encoder exists
 
     startTime = QDateTime::currentMSecsSinceEpoch();
     QCOMPARE(m_codecInfo->testEncoderSupport(rawFourcc), rawSupported);
@@ -160,6 +161,17 @@ void TestVideoCodecSupportInfo::testEncoderSupport() {
     endTime = QDateTime::currentMSecsSinceEpoch();
     difference = endTime - startTime;
     qDebug() << "Checking encoder support status by VideoCodecSupportInfo took" << difference << "ms";
+
+    // case: encoder doesn't exist
+
+    QString nonexistingEncoderLocation = "/nonexistingEncoderDir/nonexistingEncoderBin";
+    QFile nonexistingEncoder(nonexistingEncoderLocation);
+    QVERIFY(!nonexistingEncoder.exists());
+    m_codecInfo->m_videoEncoderLocation = nonexistingEncoderLocation;
+    QVERIFY(!m_codecInfo->testEncoderSupport(rawFourcc));
+    QVERIFY(!m_codecInfo->testEncoderSupport(ffv1Fourcc));
+    QVERIFY(!m_codecInfo->testEncoderSupport(lagarithFourcc));
+    m_codecInfo->m_videoEncoderLocation = m_videoEncoderLocation;
 
     // These apply to basic/non-PPA OpenCV2 packages in Ubuntu 14.04.4 (Trusty)
     //QVERIFY(rawFourcc);
@@ -203,20 +215,8 @@ void TestVideoCodecSupportInfo::initialize() {
         }
     }
 
-    // case: nonexisting encoder
-
-    QVERIFY(!m_codecInfo->m_isInitialized);
-    QString nonexistingEncoderLocation = "/nonexistingEncoderDir/nonexistingEncoderBin";
-    QFile nonexistingEncoder(nonexistingEncoderLocation);
-    QVERIFY(!nonexistingEncoder.exists());
-    m_codecInfo->m_videoEncoderLocation = nonexistingEncoderLocation;
-    QVERIFY(!m_codecInfo->init());
     QVERIFY(!m_codecInfo->m_isInitialized);
     QVERIFY(!m_codecInfo->isInitialized());
-
-    // case: existing encoder
-
-    m_codecInfo->m_videoEncoderLocation = m_videoEncoderLocation;
     QVERIFY(m_codecInfo->init());
     QVERIFY(m_codecInfo->m_isInitialized);
     QVERIFY(m_codecInfo->isInitialized());

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
@@ -1,0 +1,35 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2016-06-12T20:42:53
+#
+#-------------------------------------------------
+
+QT       += testlib core widgets
+
+QT       -= gui
+
+TARGET = testVideoCodecSupportInfo
+CONFIG   += console
+CONFIG   -= app_bundle
+
+TEMPLATE = app
+
+QMAKE_CXXFLAGS += -std=c++11
+
+CONFIG += c++11
+
+DEFINES += SRCDIR=\\\"$$PWD/\\\" \
+    _UNIT_TEST_
+
+include(../../src/opencv.pri)
+
+INCLUDEPATH += ../../src \
+    ../mock
+
+HEADERS += ../../src/videocodecsupportinfo.h \
+    ../../src/config.h
+
+SOURCES += testVideoCodecSupportInfo.cpp \
+    ../../src/videocodecsupportinfo.cpp \
+    ../mock/mockconfig.cpp
+

--- a/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
+++ b/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
@@ -23,13 +23,10 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\" \
 
 include(../../src/opencv.pri)
 
-INCLUDEPATH += ../../src \
-    ../mock
+INCLUDEPATH += ../../src
 
-HEADERS += ../../src/videocodecsupportinfo.h \
-    ../../src/config.h
+HEADERS += ../../src/videocodecsupportinfo.h
 
 SOURCES += testVideoCodecSupportInfo.cpp \
-    ../../src/videocodecsupportinfo.cpp \
-    ../mock/mockconfig.cpp
+    ../../src/videocodecsupportinfo.cpp
 


### PR DESCRIPTION
This pull request is a duplicate of UFOID/UFO-Detector#39. It was merged accidentally so needed to create a new one.

**Changes**
- Auto-detect supported codecs. New class VideoCodecSupportInfo does this.
- Only show supported codecs to user.
- In Recorder, prefer OpenCV for encoding. If OpenCV doesn't support codec then use ffmpeg/avconv. No support -> use raw video.
- Settings file uses clear-text FOURCC string for user-readability. IYUV = raw video codec.
- Addressing UFOID/UFO-Detector#26: doing test & application part of codec verification

**Issues**
- Windows seems to not show FFV1 codec in settings dialog even if it should.
