### PR TITLE
Compiles in Unix (C++14 flags)

### DIFF
--- a/ui-qt/Detector.pro
+++ b/ui-qt/Detector.pro
@@ -14,7 +14,10 @@ TEMPLATE = app
 win32:CONFIG += windows
 win64:CONFIG += windows
 
-
+unix {
+    QMAKE_CXXFLAGS += -std=c++1y
+    CONFIG += c++1y
+}
 
 RC_ICONS = app.ico
 


### PR DESCRIPTION
With g++ versions < 5.2 the flags must be c++1y. Newer g++ versions should have flags as c++14.

http://stackoverflow.com/questions/31965413/compile-c14-code-with-g