### PR TITLE
Changed detection area file format to polygon based + enabled editing

### DIFF
--- a/lang/detector_fi.ts
+++ b/lang/detector_fi.ts
@@ -4,42 +4,22 @@
 <context>
     <name>ActualDetector</name>
     <message>
-        <location filename="../src/actualdetector.cpp" line="85"/>
+        <location filename="../ufo-detector-engine/actualdetector.cpp" line="92"/>
         <source>WARNING: could not load bird detection data (cascade classifier file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="185"/>
+        <location filename="../ufo-detector-engine/actualdetector.cpp" line="205"/>
         <source>Positive detection - starting video recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="245"/>
-        <source>One object identified as a bird</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/actualdetector.cpp" line="251"/>
-        <source>Finished recording - All found objects negative: removed video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/actualdetector.cpp" line="260"/>
-        <source>Finished recording - At least one object found positive: saved video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/actualdetector.cpp" line="266"/>
-        <source>Finished recording - Minimum required positive detections not met: removed video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/actualdetector.cpp" line="564"/>
+        <location filename="../ufo-detector-engine/actualdetector.cpp" line="584"/>
         <source>%1 area(s) being ignored in order to filter the moon and stars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/actualdetector.cpp" line="747"/>
+        <location filename="../ufo-detector-engine/actualdetector.cpp" line="386"/>
         <source>ERROR: Selected area of detection does not match camera resolution. Re-select area of detection.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -47,132 +27,180 @@
 <context>
     <name>CameraResolutionDialog</name>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="46"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="46"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="97"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="97"/>
         <source>- If you get problems, reset camera settings in the settings file and contact the developers at contact@ufoid.net.</source>
         <extracomment>Bullet list item</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="142"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="142"/>
         <source>Available resolutions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="26"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="26"/>
         <source>Check supported web camera resolutions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="59"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="59"/>
         <source>- Checking the supported web camera resolutions causes problems with some web camera brands.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="78"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="78"/>
         <source>- It is recommended to read your webcam specification or manual for supported resolutions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="112"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="112"/>
         <source>Checking status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="171"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="171"/>
         <source>&amp;Start checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="181"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="181"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/cameraresolutiondialog.ui" line="188"/>
+        <location filename="../ui-qt/cameraresolutiondialog.ui" line="188"/>
         <source>&amp;Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DataManager</name>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="288"/>
+        <source>DataManager: failed to open result data file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="300"/>
+        <source>DataManager: problem writing to result data file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="323"/>
+        <source>Failed to open the detection area file %1. Please create it in Settings dialog or manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="329"/>
+        <source>Error reading the detection area file %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="338"/>
+        <source>Expected &lt;detectionarealist&gt; tag in detection area file but not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="345"/>
+        <source>More than one detection areas defined, combining all together</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="354"/>
+        <source>Expected &lt;detectionarea&gt; tag in detection area file but not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="362"/>
+        <source>Expected single &lt;camera&gt; tag in detection area. Assuming camera index 0.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ufo-detector-engine/datamanager.cpp" line="419"/>
+        <source>Detection area was clipped in order to fit the camera size.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DetectionAreaEditDialog</name>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="14"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="14"/>
         <source>Select area of detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="27"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="27"/>
         <source>Only select the sky in your area of detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="41"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="41"/>
         <source>There should be no trees, telephone lines, etc. in your selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="53"/>
-        <location filename="../src/detectionareaeditdialog.cpp" line="134"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="53"/>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="141"/>
         <source>1. Take a picture with the webcam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="65"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="65"/>
         <source>Take picture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="72"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="72"/>
         <source>Connect points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="79"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="79"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.ui" line="93"/>
+        <location filename="../ui-qt/detectionareaeditdialog.ui" line="86"/>
         <source>Save to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="43"/>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="32"/>
         <source>Could not find area file: %1 - Check area file path in settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="79"/>
-        <source>ERROR saving detection area file: no points inside area</source>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="51"/>
+        <source>ERROR saving %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="114"/>
-        <source>Detection area file saved successfully</source>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="82"/>
+        <source>Saved %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="119"/>
-        <source>ERROR saving the detection area file. Check &quot;Detection area file&quot; path in settings.</source>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="153"/>
+        <source>2. Edit current detection area or take a new picture to create a new area.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="127"/>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="158"/>
+        <source>2. Click to create points around the area of the detection. Connect the first and last points using the &quot;Connect&quot; button.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="130"/>
         <source>3. Press the &quot;Save&quot; button to save your detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="145"/>
-        <source>2. Click to create points around the area of the dection. Connect the first and last points using the &quot;Connect&quot; button.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/detectionareaeditdialog.cpp" line="162"/>
+        <location filename="../ui-qt/detectionareaeditdialog.cpp" line="132"/>
         <source>ERROR not enough points. Draw at least three points around your area of detection.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -180,68 +208,68 @@
 <context>
     <name>ImageExplorer</name>
     <message>
-        <location filename="../src/imageexplorer.ui" line="14"/>
-        <location filename="../src/imageexplorer.ui" line="105"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="14"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="105"/>
         <source>Upload images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.ui" line="25"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="25"/>
         <source>Help improve the algorithm by uploading the images which show a known object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.ui" line="32"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="32"/>
         <source>Click here for an example of what to upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.ui" line="41"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="41"/>
         <source>Back to main folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.ui" line="71"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="71"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.ui" line="98"/>
+        <location filename="../ui-qt/imageexplorer.ui" line="98"/>
         <source>Clear selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="38"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="38"/>
         <source>Activate the saving of images in the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="95"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="95"/>
         <source>%1 uploaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="100"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="100"/>
         <source>All images uploaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="101"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="101"/>
         <source>Thank you for helping to improve the algorithm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="108"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="108"/>
         <source>ERROR cannot upload image. Contact the developer if the error persists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="116"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="116"/>
         <source>Upload started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/imageexplorer.cpp" line="173"/>
+        <location filename="../ui-qt/imageexplorer.cpp" line="173"/>
         <source>No images selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -249,210 +277,210 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.ui" line="429"/>
+        <location filename="../ui-qt/mainwindow.ui" line="429"/>
         <source>MainWindow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="532"/>
-        <location filename="../src/mainwindow.cpp" line="411"/>
+        <location filename="../ui-qt/mainwindow.ui" line="532"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="462"/>
         <source>Detection not running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="571"/>
+        <location filename="../ui-qt/mainwindow.ui" line="571"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Deactivate for better performance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="574"/>
+        <location filename="../ui-qt/mainwindow.ui" line="574"/>
         <source>Display webcam during detection (not recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="621"/>
-        <location filename="../src/mainwindow.cpp" line="505"/>
+        <location filename="../ui-qt/mainwindow.ui" line="621"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="508"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="668"/>
+        <location filename="../ui-qt/mainwindow.ui" line="668"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="688"/>
+        <location filename="../ui-qt/mainwindow.ui" line="688"/>
         <source>Filter noise by pixel size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="700"/>
-        <location filename="../src/mainwindow.ui" line="784"/>
+        <location filename="../ui-qt/mainwindow.ui" line="700"/>
+        <location filename="../ui-qt/mainwindow.ui" line="784"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="752"/>
+        <location filename="../ui-qt/mainwindow.ui" line="752"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="772"/>
+        <location filename="../ui-qt/mainwindow.ui" line="772"/>
         <source>Select threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="816"/>
+        <location filename="../ui-qt/mainwindow.ui" line="816"/>
         <source>0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="833"/>
+        <location filename="../ui-qt/mainwindow.ui" line="833"/>
         <source>Number of recorded videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="869"/>
-        <location filename="../src/mainwindow.cpp" line="420"/>
+        <location filename="../ui-qt/mainwindow.ui" line="869"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="471"/>
         <source>Start detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="887"/>
+        <location filename="../ui-qt/mainwindow.ui" line="887"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="894"/>
+        <location filename="../ui-qt/mainwindow.ui" line="894"/>
         <source>Clear messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="901"/>
+        <location filename="../ui-qt/mainwindow.ui" line="901"/>
         <source>Upload images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="911"/>
+        <location filename="../ui-qt/mainwindow.ui" line="911"/>
         <source>Start rec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="73"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="78"/>
         <source>For feedback and bug reports contact the developer at contact@ufoid.net</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="198"/>
-        <location filename="../src/mainwindow.cpp" line="366"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="230"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="416"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="198"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="230"/>
         <source>Playing video file while recording another video is disabled. Wait until the recording has finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="216"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="248"/>
         <source>Delete video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="217"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="249"/>
         <source>Do you want to permanently delete this video?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="248"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="280"/>
         <source>Video list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="249"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="281"/>
         <source>Delete selected items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="260"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="292"/>
         <source>Delete videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="261"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="293"/>
         <source>Do you really want to delete the selected videos?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="291"/>
-        <location filename="../src/mainwindow.cpp" line="313"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="341"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="363"/>
         <source>%1 - Positive: %2 Negative: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="294"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="344"/>
         <source>%1 - Positive detections: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="316"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="366"/>
         <source>%1 - Negative detections: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="325"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="375"/>
         <source>ERROR: XML file containing the detection area information was not read correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="326"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="376"/>
         <source>ERROR: Detection is not working. Select area of detection first in the settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="366"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="416"/>
         <source>Cannot edit settings when detection process is running. Stop the detection process first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="391"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="442"/>
         <source>Detection started at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="393"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="444"/>
         <source>Stop detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="397"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="448"/>
         <source>Failed to start detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="542"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="545"/>
         <source>Error: Selected webcam resolution is NOT ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="651"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="576"/>
         <source>ERROR: Found webcam but video frame could not be read. Reconnect and check resolution in settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="811"/>
-        <location filename="../src/mainwindow.cpp" line="816"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="649"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="654"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="811"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="649"/>
         <source>Select the pixel size of noise that will be ignored in the detection. 
 Recommended value: 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="816"/>
+        <location filename="../ui-qt/mainwindow.cpp" line="654"/>
         <source>Select the threshold filter value that will be used in the motion detection algorithm. 
 Increase the value if clouds are being detected. 
 Recommended value: 10</source>
@@ -462,184 +490,196 @@ Recommended value: 10</source>
 <context>
     <name>SettingsDialog</name>
     <message>
-        <location filename="../src/settingsdialog.ui" line="14"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="14"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="250"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="304"/>
         <source>Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="260"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="314"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="88"/>
-        <location filename="../src/settingsdialog.ui" line="189"/>
-        <location filename="../src/settingsdialog.ui" line="196"/>
-        <location filename="../src/settingsdialog.ui" line="210"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="57"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="64"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="71"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="141"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="172"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="148"/>
         <source>UFOID user token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="47"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="203"/>
         <source>Image path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="122"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="177"/>
         <source>Webcam 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="127"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="182"/>
         <source>Webcam 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="132"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="187"/>
         <source>Webcam 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="137"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="192"/>
         <source>Webcam 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="152"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="217"/>
         <source>Video path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="54"/>
-        <location filename="../src/settingsdialog.ui" line="61"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="78"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="169"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="336"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="312"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="264"/>
         <source>Draw rectangle around object in the video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="289"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="248"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="296"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="255"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="108"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="112"/>
         <source>Save images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="217"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="85"/>
         <source>Select webcam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="73"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="97"/>
         <source>Minimum required number of positive detections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="95"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="155"/>
         <source>Video codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="145"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="210"/>
+        <source>Filter airplanes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui-qt/settingsdialog.ui" line="224"/>
         <source>Detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="239"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="293"/>
         <source>Select detection area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.ui" line="203"/>
+        <location filename="../ui-qt/settingsdialog.ui" line="162"/>
         <source>Select resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="118"/>
-        <location filename="../src/settingsdialog.cpp" line="200"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="99"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="175"/>
         <source>Select Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="141"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="120"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="126"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="141"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="120"/>
         <source>Unknown camera aspect ratio. Please change camera width and/or height. Settings are not saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="147"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="126"/>
+        <source>Value entered for Airplane filter not correct. Click the &quot;?&quot; button next to the field for more information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../ui-qt/settingsdialog.cpp" line="133"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="147"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="133"/>
         <source>Settings saved successfully. Restart the application to apply the changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="191"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="166"/>
         <source>Select the detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="191"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="166"/>
         <source>XML files (*.xml)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="212"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="187"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="212"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="187"/>
         <source>Restart the application before creating detection area file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="255"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="213"/>
         <source>Codec Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="255"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="213"/>
         <source>Raw Video results is big file sizes. 
 A lossless codec is recommended. 
 Windows 8 users should use the Lagarith Codec.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="260"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="218"/>
         <source>UFOID.net User Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/settingsdialog.cpp" line="260"/>
+        <location filename="../ui-qt/settingsdialog.cpp" line="218"/>
         <source>Copy the user token from your UFOID account into this field to enable the upload feature. 
 The code can be found at http://ufoid.net/profile/edit</source>
         <translation type="unfinished"></translation>
@@ -648,22 +688,22 @@ The code can be found at http://ufoid.net/profile/edit</source>
 <context>
     <name>UpdateApplicationDialog</name>
     <message>
-        <location filename="../src/updateapplicationdialog.ui" line="14"/>
+        <location filename="../ui-qt/updateapplicationdialog.ui" line="14"/>
         <source>New update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/updateapplicationdialog.ui" line="25"/>
+        <location filename="../ui-qt/updateapplicationdialog.ui" line="25"/>
         <source>New UFO Detector update available!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/updateapplicationdialog.ui" line="47"/>
+        <location filename="../ui-qt/updateapplicationdialog.ui" line="47"/>
         <source>Download here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/updateapplicationdialog.cpp" line="28"/>
+        <location filename="../ui-qt/updateapplicationdialog.cpp" line="28"/>
         <source>New version: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -671,17 +711,17 @@ The code can be found at http://ufoid.net/profile/edit</source>
 <context>
     <name>VideoCodecSupportInfo</name>
     <message>
-        <location filename="../src/videocodecsupportinfo.cpp" line="40"/>
+        <location filename="../ufo-detector-engine/videocodecsupportinfo.cpp" line="40"/>
         <source>Raw Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videocodecsupportinfo.cpp" line="41"/>
+        <location filename="../ufo-detector-engine/videocodecsupportinfo.cpp" line="41"/>
         <source>FFV1 Lossless Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videocodecsupportinfo.cpp" line="42"/>
+        <location filename="../ufo-detector-engine/videocodecsupportinfo.cpp" line="42"/>
         <source>Lagarith Lossless Video</source>
         <translation type="unfinished"></translation>
     </message>
@@ -689,32 +729,32 @@ The code can be found at http://ufoid.net/profile/edit</source>
 <context>
     <name>VideoUploaderDialog</name>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="14"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="14"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="27"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="27"/>
         <source>Upload video to UFOID.net</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="34"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="34"/>
         <source>Submit your video and have it analyzed by other users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="43"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="43"/>
         <source>Selected file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="57"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="57"/>
         <source>Output:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videouploaderdialog.ui" line="71"/>
+        <location filename="../ui-qt/videouploaderdialog.ui" line="71"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
@@ -722,17 +762,17 @@ The code can be found at http://ufoid.net/profile/edit</source>
 <context>
     <name>VideoWidget</name>
     <message>
-        <location filename="../src/videowidget.cpp" line="64"/>
+        <location filename="../ui-qt/videowidget.cpp" line="64"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videowidget.cpp" line="69"/>
+        <location filename="../ui-qt/videowidget.cpp" line="69"/>
         <source>Share</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/videowidget.cpp" line="75"/>
+        <location filename="../ui-qt/videowidget.cpp" line="75"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ufo-detector-engine/Ctracker.cpp
+++ b/ufo-detector-engine/Ctracker.cpp
@@ -162,7 +162,7 @@ void CTracker::updateEmpty(){
     for(int i=0; i < (int)tracks.size(); i++)
     {
         tracks[i]->skipped_frames++;
-        if((int)tracks[i]->skipped_frames > maximum_allowed_skipped_frames)
+        if((int)tracks[i]->skipped_frames > (long)maximum_allowed_skipped_frames)
         {
 
             if(tracks[i]->posCounter>tracks[i]->negCounter){

--- a/ufo-detector-engine/Detector.cpp
+++ b/ufo-detector-engine/Detector.cpp
@@ -15,6 +15,10 @@ CDetector::~CDetector(void)
 //----------------------------------------------------------------------
 void CDetector::DetectContour(cv::Mat& img, std::vector<cv::Rect>& Rects,std::vector<cv::Point2d>& centers, cv::Rect& croppedRect)
 {
+    // unused
+    (void)Rects;
+    (void)centers;
+
 	m_rects.clear();
 	m_centers.clear();
 	std::vector<std::vector<cv::Point> > contours;

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -34,7 +34,9 @@ ActualDetector::ActualDetector(Camera *cameraPtr, Config *configPtr, QObject *pa
 
     m_detectionAreaFile = DETECTION_AREA_FILE.toStdString();
     m_resultImageDirNameBase = IMAGEPATH.toStdString();
-    m_noiseLevel = getStructuringElement(MORPH_RECT, Size(1,1));
+
+    setNoiseLevel(m_config->noiseFilterPixelSize());
+    setThresholdLevel(m_config->motionThreshold());
 
     m_recorder = new Recorder(m_camPtr, m_config);
 

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -117,7 +117,10 @@ void ActualDetector::detectingThread()
     bool isPositiveRectangle;
     int threadYieldPauseUsec = 1000;
     int numberOfChanges = 0;
-
+    int frameCount = 0;
+    int framesInFpsMeasurement = OUTPUT_FPS * 10;
+    bool fpsMeasurementDone = false;
+    QTime fpsMeasurementTimer;
 
     CDetector* detector=new CDetector(m_currentFrame);
     vector<Point2d> centers;
@@ -126,11 +129,21 @@ void ActualDetector::detectingThread()
 
     qDebug() << "ActualDetector::detectingThread() started";
 
+    qDebug() << "Measuring ActualDetector frame rate";
+    fpsMeasurementTimer.start();
+
     while (m_isMainThreadRunning)
     {
         m_prevFrame = m_currentFrame;
         m_currentFrame = m_nextFrame;
         tempImage = m_camPtr->getWebcamFrame();
+        frameCount++;
+        if (!fpsMeasurementDone && (frameCount >= framesInFpsMeasurement)) {
+            qDebug() << "ActualDetector reading" << ((float)frameCount /
+                         (float)fpsMeasurementTimer.elapsed()) * (float)1000
+                     << "FPS on average";
+            fpsMeasurementDone = true;
+        }
 
         m_nextFrame = tempImage.clone();
         m_resultFrame = m_nextFrame;

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -821,9 +821,11 @@ bool ActualDetector::loadDetectionArea(int cameraId) {
                 QPolygon polygon;
                 for (int p = 0; p < pointList.count(); p++) {
                     QDomElement pointElement = pointList.at(p).toElement();
-                    x = pointElement.attribute("x").toInt();
-                    y = pointElement.attribute("y").toInt();
-                    polygon << QPoint(x, y);
+                    if (pointElement.nodeName() == "point") {
+                        x = pointElement.attribute("x").toInt();
+                        y = pointElement.attribute("y").toInt();
+                        polygon << QPoint(x, y);
+                    }
                 }
                 qDebug() << polygon;
                 QRect boundingRect = polygon.boundingRect();

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -18,10 +18,11 @@
 
 #include "actualdetector.h"
 
-ActualDetector::ActualDetector(Camera *cameraPtr, Config *configPtr, QObject *parent) :
-    QObject(parent), m_camPtr(cameraPtr)
+ActualDetector::ActualDetector(Camera* camera, Config* config, DataManager* dataManager, QObject *parent) :
+    QObject(parent), m_camPtr(camera)
 {
-    m_config = configPtr;
+    m_config = config;
+    m_dataManager = dataManager;
     const QString DETECTION_AREA_FILE = m_config->detectionAreaFile();
     const QString IMAGEPATH = m_config->resultImageDir() + "/";
     m_willSaveImages = m_config->saveResultImages();
@@ -38,7 +39,7 @@ ActualDetector::ActualDetector(Camera *cameraPtr, Config *configPtr, QObject *pa
     setNoiseLevel(m_config->noiseFilterPixelSize());
     setThresholdLevel(m_config->motionThreshold());
 
-    m_recorder = new Recorder(m_camPtr, m_config);
+    m_recorder = new Recorder(m_camPtr, m_config, m_dataManager);
 
     state = new DetectorState(this, m_recorder);
     state->MIN_POS_REQUIRED = m_config->minPositiveDetections();

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -131,7 +131,6 @@ void ActualDetector::detectingThread()
 
     qDebug() << "ActualDetector::detectingThread() started";
 
-    qDebug() << "Measuring ActualDetector frame rate";
     fpsMeasurementTimer.start();
 
     while (m_isMainThreadRunning)

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -289,6 +289,7 @@ void ActualDetector::detectingThread()
         std::this_thread::yield();
         std::this_thread::sleep_for(std::chrono::microseconds(threadYieldPauseUsec));
     }
+    qDebug() << "ActualDetector::detectingThread() finished";
     delete detector;    
 }
 

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -368,7 +368,7 @@ inline int ActualDetector::detectMotion(const Mat & motion, Mat & result, Mat & 
 
 bool ActualDetector::initDetectionArea() {
 
-    bool readOk = m_dataManager->readDetectionAreaFile();
+    bool readOk = m_dataManager->readDetectionAreaFile(true);
     if (!readOk) {
         return false;
     }

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -124,6 +124,8 @@ void ActualDetector::detectingThread()
     Scalar Colors[]={Scalar(255,0,0),Scalar(0,255,0),Scalar(0,0,255),Scalar(255,255,0),Scalar(0,255,255),Scalar(255,0,255),Scalar(255,127,255),Scalar(127,0,255),Scalar(127,0,127)};
     pair < vector<Point2d>,vector<Rect> > centerAndRectPair;
 
+    qDebug() << "ActualDetector::detectingThread() started";
+
     while (m_isMainThreadRunning)
     {
         m_prevFrame = m_currentFrame;

--- a/ufo-detector-engine/actualdetector.cpp
+++ b/ufo-detector-engine/actualdetector.cpp
@@ -56,9 +56,14 @@ ActualDetector::~ActualDetector()
 
 bool ActualDetector::initialize()
 {
+    chrono::high_resolution_clock::time_point startTime, endTime;
+    startTime = chrono::high_resolution_clock::now();
     if (!parseDetectionAreaFile(m_detectionAreaFile, m_region)){
         return false;
     }
+    endTime = chrono::high_resolution_clock::now();
+    chrono::duration<double, std::milli> msec = endTime - startTime;
+    qDebug() << "Parsing detection area file took" << msec.count() << "ms";
     state->resetState();
 
     m_prevFrame = m_camPtr->getWebcamFrame();

--- a/ufo-detector-engine/actualdetector.h
+++ b/ufo-detector-engine/actualdetector.h
@@ -146,6 +146,14 @@ private:
                      std::vector<cv::Point> &m_region,
                      int m_maxDeviation);
     bool parseDetectionAreaFile(std::string file_region, std::vector<cv::Point> &m_region);
+
+    /**
+     * @brief Load detection area from file.
+     * @param cameraId camera ID for which to load the detection area
+     * @return true on success, false on failure
+     */
+    bool loadDetectionArea(int cameraId);
+
     bool lightDetection(cv::Rect &rectangle, cv::Mat &croppedImage);
     void detectingThread();
     void detectingThreadHigh();

--- a/ufo-detector-engine/actualdetector.h
+++ b/ufo-detector-engine/actualdetector.h
@@ -147,11 +147,11 @@ private:
                      int m_maxDeviation);
 
     /**
-     * @brief Load detection area from file.
+     * @brief Initialize detection area.
      * Currently combining all defined detection areas into a single one.
      * @return true on success, false on failure
      */
-    bool loadDetectionArea();
+    bool initDetectionArea();
 
     bool lightDetection(cv::Rect &rectangle, cv::Mat &croppedImage);
     void detectingThread();

--- a/ufo-detector-engine/actualdetector.h
+++ b/ufo-detector-engine/actualdetector.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include "recorder.h"
 #include "config.h"
+#include "datamanager.h"
 #include <time.h>
 #include <QObject>
 #include "opencv2/objdetect/objdetect.hpp"
@@ -53,7 +54,7 @@ class ActualDetector : public QObject
  Q_OBJECT
 
 public:
-    ActualDetector(Camera *cameraPtr = 0, Config *configPtr = 0, QObject *parent = 0);
+    ActualDetector(Camera* camera, Config* config, DataManager* dataManager, QObject *parent = 0);
     ~ActualDetector();
 
     /**
@@ -95,6 +96,7 @@ private:
     Recorder* m_recorder;
     Camera* m_camPtr;
     Config* m_config;
+    DataManager* m_dataManager;
     cv::Mat m_resultFrame;
     cv::Mat m_resultFrameCropped;
     cv::Mat m_prevFrame;

--- a/ufo-detector-engine/actualdetector.h
+++ b/ufo-detector-engine/actualdetector.h
@@ -145,14 +145,13 @@ private:
     inline int detectMotion(const cv::Mat & m_motion, cv::Mat & m_resultFrame, cv::Mat & m_resultFrameCropped,
                      std::vector<cv::Point> &m_region,
                      int m_maxDeviation);
-    bool parseDetectionAreaFile(std::string file_region, std::vector<cv::Point> &m_region);
 
     /**
      * @brief Load detection area from file.
-     * @param cameraId camera ID for which to load the detection area
+     * Currently combining all defined detection areas into a single one.
      * @return true on success, false on failure
      */
-    bool loadDetectionArea(int cameraId);
+    bool loadDetectionArea();
 
     bool lightDetection(cv::Rect &rectangle, cv::Mat &croppedImage);
     void detectingThread();

--- a/ufo-detector-engine/camera.h
+++ b/ufo-detector-engine/camera.h
@@ -72,7 +72,6 @@ public:
      * @return
      */
     cv::Mat getWebcamFrame();
-    void stopReadingWebcam();
     bool isWebcamOpen();
 
     /**
@@ -105,13 +104,9 @@ private:
     int m_index;    ///< camera index as used by OpenCV
     int m_width;
     int m_height;
-    std::atomic<bool> isReadingWebcam;
     cv::VideoCapture* m_webcam;
     cv::Mat videoFrame;
-    cv::Mat frameToReturn;
     std::mutex mutex;
-    void readWebcamFrame();     ///< thread method for continuous reading of frames
-    std::unique_ptr<std::thread> threadReadFrame;
     CameraInfo* m_cameraInfo;
     bool m_initialized;     ///< whether camera is initialized or not
 

--- a/ufo-detector-engine/config.cpp
+++ b/ufo-detector-engine/config.cpp
@@ -77,6 +77,7 @@ Config::Config(QObject *parent) : QObject(parent)
     m_defaultResultDataFileName = m_defaultDetectionDataDir + "/logs.xml";
     m_defaultResultDocumentDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)+"/UFO ID";
     m_defaultDetectionAreaFileName = m_defaultDetectionDataDir + "/detectionArea.xml";
+    m_defaultDetectionAreaSize = 0;
 
     m_defaultResultVideoDir = m_defaultResultDocumentDir + "/Videos";
     if ((QSysInfo::windowsVersion()==QSysInfo::WV_WINDOWS8) || (QSysInfo::windowsVersion()==QSysInfo::WV_WINDOWS8_1)) {

--- a/ufo-detector-engine/config.h
+++ b/ufo-detector-engine/config.h
@@ -27,6 +27,8 @@
 #include <QStandardPaths>
 #include <QDebug>
 
+#define APPLICATION_VERSION "0.7.0"
+
 /**
  * @brief Global configuration variables for UFO-Detector
  *

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -425,3 +425,33 @@ bool DataManager::readDetectionAreaFile(bool clipToCamera) {
 QList<QPolygon*>& DataManager::detectionArea() {
     return m_detectionAreaPolygons;
 }
+
+bool DataManager::resetDetectionAreaFile(bool overwrite) {
+    QFile detectionAreaFile(m_config->detectionAreaFile());
+    if (detectionAreaFile.exists() && !overwrite) {
+        return false;
+    }
+    if (!detectionAreaFile.open(QFile::ReadWrite)) {
+        return false;
+    }
+    int id = m_config->cameraIndex();
+    int width = m_config->cameraWidth();
+    int height = m_config->cameraHeight();
+    QTextStream out(&detectionAreaFile);
+
+    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << endl;
+    out << "<detectionarealist>" << endl;
+    out << "  <detectionarea>" << endl;
+    out << "    <camera id=\"" << id << "\" width=\"" << width
+        << "\" height=\"" << height << "\"/>" << endl;
+    out << "    <polygon>" << endl;
+    out << "      <point x=\"0\" y=\"0\"/>" << endl;
+    out << "      <point x=\"0\" y=\"" << (height - 1) << "\"/>" << endl;
+    out << "      <point x=\"" << (width - 1) << "\" y=\"" << (height - 1) << "\"/>" << endl;
+    out << "      <point x=\"" << (width - 1) << "\" y=\"0\"/>" << endl;
+    out << "    </polygon>" << endl;
+    out << "  </detectionarea>" << endl;
+    out << "</detectionarealist>" << endl;
+    detectionAreaFile.close();
+    return true;
+}

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -273,3 +273,33 @@ void DataManager::handleBirdClassifierReply(QNetworkReply* reply) {
     }
     reply->deleteLater();
 }
+
+void DataManager::saveResultData(QString dateTime, QString videoLength) {
+    /// @todo create root element here if it doesn't exist
+    QDomElement rootElement = m_resultDataDomDocument.firstChildElement();
+    QDomElement node = m_resultDataDomDocument.createElement("Video");
+    node.setAttribute("Pathname", m_config->resultVideoDir());
+    node.setAttribute("DateTime", dateTime);
+    node.setAttribute("Length", videoLength);
+    rootElement.appendChild(node);
+
+    if(!m_resultDataFile.open(QIODevice::WriteOnly | QIODevice::Text))
+    {
+        qDebug() << "DataManager: failed to open result data file" << m_resultDataFile.fileName();
+        return;
+    }
+    else
+    {
+        QTextStream stream(&m_resultDataFile);
+        stream.setCodec("UTF-8");
+        /// @todo find way to append just the latest entry into the file, this is not scalable
+        stream << m_resultDataDomDocument.toString();
+        if (stream.status() != QTextStream::Ok)
+        {
+            qDebug() << "DataManager: problem writing to result data file" << m_resultDataFile.fileName();
+        }
+        m_resultDataFile.flush();
+        m_resultDataFile.close();
+    }
+    emit resultDataSaved(m_config->resultVideoDir(), dateTime, videoLength);
+}

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -320,7 +320,7 @@ bool DataManager::readDetectionAreaFile(bool clipToCamera) {
     bool polygonWasClosed = false;
 
     if(!areaFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        QString errorMsg = tr("Failed to open the detection area file %1").arg(areaFile.fileName());
+        QString errorMsg = tr("Failed to open the detection area file %1. Please create it in Settings dialog or manually.").arg(areaFile.fileName());
         emit messageBroadcasted(errorMsg);
         return false;
     }

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -372,8 +372,8 @@ bool DataManager::readDetectionAreaFile(bool clipToCamera) {
             }
         }
 
-        cameraRectangle << QPoint(0, 0) << QPoint(0, cameraHeight)
-                        << QPoint(cameraWidth, cameraHeight) << QPoint(cameraWidth, 0);
+        cameraRectangle << QPoint(0, 0) << QPoint(0, cameraHeight - 1)
+                        << QPoint(cameraWidth - 1, cameraHeight - 1) << QPoint(cameraWidth - 1, 0);
 
         while (!m_detectionAreaPolygons.isEmpty()) {
             QPolygon* polygon = m_detectionAreaPolygons.takeLast();

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -357,6 +357,11 @@ bool DataManager::readDetectionAreaFile() {
             emit messageBroadcasted(errorMsg);
         }
 
+        while (!m_detectionAreaPolygons.isEmpty()) {
+            QPolygon* polygon = m_detectionAreaPolygons.takeLast();
+            delete polygon;
+        }
+
         for (int a = 0; a < areaNodes.count(); a++) {
             QDomNode areaSubNode = areaNodes.at(a);
 

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -431,7 +431,7 @@ bool DataManager::resetDetectionAreaFile(bool overwrite) {
     if (detectionAreaFile.exists() && !overwrite) {
         return false;
     }
-    if (!detectionAreaFile.open(QFile::ReadWrite)) {
+    if (!detectionAreaFile.open(QFile::WriteOnly | QFile::Truncate)) {
         return false;
     }
     int id = m_config->cameraIndex();

--- a/ufo-detector-engine/datamanager.cpp
+++ b/ufo-detector-engine/datamanager.cpp
@@ -1,0 +1,275 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "datamanager.h"
+
+DataManager::DataManager(Config* config, QObject *parent) : QObject(parent)
+{
+    m_config = config;
+    m_initialized = false;
+    m_applicationVersion = APPLICATION_VERSION;
+}
+
+bool DataManager::init() {
+    bool ok = false;
+    bool allOk = true;
+
+    m_resultDataFile.setFileName(m_config->resultDataFile());
+
+    ok = checkFolders();
+    if (!ok) {
+        allOk = false;
+    }
+
+    ok = checkDetectionAreaFile();
+    if (!ok) {
+        allOk = false;
+    }
+
+    ok = readResultDataFile();
+    if (!ok) {
+        allOk = false;
+    }
+
+    m_initialized = allOk;
+    return allOk;
+}
+
+bool DataManager::checkFolders() {
+    QDir videoFolder(m_config->resultVideoDir());
+    QFileInfo detectionAreaFileInfo(m_config->detectionAreaFile());
+    QFileInfo resultDataFileInfo(m_config->resultDataFile());
+    QFileInfo birdTrainingDataFileInfo(m_config->birdClassifierTrainingFile());
+    QDir detectionAreaFileFolder(detectionAreaFileInfo.absoluteDir());
+    QDir resultDataFileFolder(resultDataFileInfo.absoluteDir());
+    QDir birdTrainingDataFileFolder(birdTrainingDataFileInfo.absoluteDir());
+    bool ok = false;
+    bool allOk = true;
+
+    if (!(videoFolder.exists() && !m_config->resultVideoDir().isEmpty()))
+    {
+        qDebug() << "creating video and image folders";
+        ok = videoFolder.mkpath(m_config->resultImageDir());
+        if (!ok) {
+            allOk = false;
+        }
+        ok = videoFolder.mkpath(m_config->resultVideoDir());
+        if (!ok) {
+            allOk = false;
+        }
+    }
+
+    if (!detectionAreaFileFolder.exists() && !detectionAreaFileFolder.absolutePath().isEmpty()) {
+        qDebug() << "Creating folder for detection area file:" << detectionAreaFileFolder.absolutePath();
+        ok = detectionAreaFileFolder.mkpath(detectionAreaFileFolder.absolutePath());
+        if (!ok) {
+            allOk = false;
+        }
+    }
+
+    if (!resultDataFileFolder.exists() && !resultDataFileFolder.absolutePath().isEmpty()) {
+        qDebug() << "Creating folder for result data file:" << resultDataFileFolder.absolutePath();
+        ok = resultDataFileFolder.mkpath(resultDataFileFolder.absolutePath());
+        if (!ok) {
+            allOk = false;
+        }
+    }
+
+    if (!birdTrainingDataFileFolder.exists() && !birdTrainingDataFileFolder.absolutePath().isEmpty()) {
+        qDebug() << "Creating folder for bird classifier training data file:" << birdTrainingDataFileFolder.absolutePath();
+        ok = birdTrainingDataFileFolder.mkpath(birdTrainingDataFileFolder.absolutePath());
+        if (!ok) {
+            allOk = false;
+        }
+    }
+    return allOk;
+}
+
+bool DataManager::checkDetectionAreaFile() {
+    QFile areaFile(m_config->detectionAreaFile());
+    if(areaFile.exists()) {
+        qDebug() << "DataManager: found detection area file";
+        return true;
+    }
+    qDebug() << "DataManager: couldn't find detection area file";
+    return false;
+}
+
+void DataManager::downloadBirdClassifierFile() {
+    disconnect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this,
+        SLOT(handleUpdateReply(QNetworkReply*)));
+    connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this,
+        SLOT(handleBirdClassifierReply(QNetworkReply*)));
+    QNetworkRequest request;
+    request.setUrl(QUrl("http://ufoid.net/cascade.xml"));
+    request.setRawHeader( "User-Agent" , "Mozilla Firefox" );
+    m_networkAccessManager->get(request);
+}
+
+bool DataManager::readResultDataFile() {
+    bool ok = false;
+    if(m_resultDataFile.exists()) {
+        /// @todo only update result data file periodically, no need to read/write all the time?
+        ok = m_resultDataFile.open(QIODevice::ReadOnly | QIODevice::Text);
+        if(!ok) {
+            qDebug() << "DataManager: failed to read the result data file" << m_resultDataFile.fileName();
+        } else {
+            ok = m_resultDataDomDocument.setContent(&m_resultDataFile);
+            if (!ok) {
+                qDebug() << "DataManager: failed to load the result data file" << m_resultDataFile.fileName();
+            } else {
+                qDebug() << "Correctly loaded root element from result data file";
+            }
+            m_resultDataFile.close();
+        }
+        return ok;
+    } else {
+        ok = m_resultDataFile.open(QIODevice::WriteOnly | QIODevice::Text);
+        if(!ok) {
+            qDebug() << "Failed to create result data file" << m_resultDataFile.fileName();
+        } else {
+            qDebug() << "Creating result data file" << m_resultDataFile.fileName();
+            QDomDocument tempFirstTime;
+            tempFirstTime.appendChild(tempFirstTime.createElement("UFOID"));
+            QTextStream stream(&m_resultDataFile);
+            stream << tempFirstTime.toString();
+            m_resultDataFile.close();
+            /// @todo refactor result data file creation and reading into separate methods
+            return readResultDataFile();
+        }
+    }
+    return false;
+}
+
+QDomDocument* DataManager::resultDataDomDocument(bool readFile) {
+    if (readFile) {
+        readResultDataFile();
+    }
+    return &m_resultDataDomDocument;
+}
+
+bool DataManager::removeVideo(QString dateTime) {
+    QDomNode node = m_resultDataDomDocument.firstChildElement().firstChild();
+    while( !node.isNull())
+    {
+        if( node.isElement())
+        {
+            QDomElement element = node.toElement();
+            QString dateInXML = element.attribute("DateTime");
+            if (dateInXML.compare(dateTime)==0)
+            {
+              m_resultDataDomDocument.firstChildElement().removeChild(node);
+              if(!m_resultDataFile.open(QIODevice::WriteOnly | QIODevice::Text))
+              {
+                  qDebug() <<  "Failed to open result data file for item deletion";
+                  return false;
+              }
+              else
+              {
+                  QTextStream stream(&m_resultDataFile);
+                  stream.setCodec("UTF-8");
+                  stream << m_resultDataDomDocument.toString();
+                  m_resultDataFile.close();
+              }
+              break;
+            }
+        }
+        node = node.nextSibling();
+    }
+    return true;
+}
+
+void DataManager::checkForUpdates() {
+    m_networkAccessManager = new QNetworkAccessManager();
+    connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(handleUpdateReply(QNetworkReply*)) );
+    QNetworkRequest request;
+    request.setUrl(QUrl("http://ufoid.net/version.xml"));
+    request.setRawHeader( "User-Agent" , "Mozilla Firefox" );
+    m_networkAccessManager->get(request);
+}
+
+void DataManager::handleUpdateReply(QNetworkReply* reply) {
+    QByteArray data = reply->readAll();
+    qDebug() << "Downloaded version data," << data.size() << "bytes";
+    QDomDocument versionXML;
+
+    if(!versionXML.setContent(data))
+    {
+        qWarning() << "Failed to parse downloaded version data";
+    }
+    else
+    {
+        QDomElement root;
+        root=versionXML.firstChildElement();
+        QString newVersion;
+        int currentClassifierVersion = 1;
+        std::queue<QString> messageInXML;
+
+        QDomNode node = root.firstChild();
+        while( !node.isNull())
+        {
+            if( node.isElement())
+            {
+                if(node.nodeName()=="version")
+                {
+                    QDomElement element = node.toElement();
+                    newVersion=element.text();
+                }
+                if(node.nodeName()=="classifier")
+                {
+                    QDomElement element = node.toElement();
+                    currentClassifierVersion=element.text().toInt();
+                }
+                if(node.nodeName()=="message")
+                {
+                    QDomElement element = node.toElement();
+                    messageInXML.push(element.text());
+                }
+            }
+            node = node.nextSibling();
+        }
+
+        if(newVersion > m_applicationVersion)
+        {
+            emit newApplicationVersionAvailable(newVersion, messageInXML);
+        }
+        else if (currentClassifierVersion > m_config->classifierVersion()) {
+            downloadBirdClassifierFile();
+        }
+    }
+    reply->deleteLater();
+}
+
+void DataManager::handleBirdClassifierReply(QNetworkReply* reply) {
+    if(reply->error() == QNetworkReply::NoError)
+    {
+        QByteArray data = reply->readAll();
+        qDebug() <<  "Downloaded bird classifier data," << data.size() << "bytes";
+        QFile file(m_config->birdClassifierTrainingFile());
+        /// @todo handle file open&write error
+        file.open(QIODevice::WriteOnly);
+        file.write(data);
+        file.close();
+        /// @todo put classifier version inside the file or otherwise get real version number
+        m_config->setClassifierVersion(m_config->classifierVersion()+1);
+        qDebug() <<  "Updated bird classifier file";
+    } else {
+        qDebug() << "Failed to receive bird classifier file";
+    }
+    reply->deleteLater();
+}

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -72,9 +72,10 @@ public:
 
     /**
      * @brief Read detection area file.
+     * @param clipToCamera crop polygons which don't fit into camera image size
      * @return true on success, false on failure
      */
-    bool readDetectionAreaFile();
+    bool readDetectionAreaFile(bool clipToCamera);
 
     QList<QPolygon*>& detectionArea();
 

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -79,6 +79,13 @@ public:
 
     QList<QPolygon*>& detectionArea();
 
+    /**
+     * @brief Reset detection area file.
+     * @param overwrite force file overwrite
+     * @return true on success, false on failure
+     */
+    bool resetDetectionAreaFile(bool overwrite);
+
 #ifndef _UNIT_TEST_
 private:
 #endif

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -72,6 +72,8 @@ public:
      */
     void checkForUpdates();
 
+    void saveResultData(QString dateTime, QString videoLength);
+
 #ifndef _UNIT_TEST_
 private:
 #endif
@@ -123,6 +125,14 @@ signals:
      * @param messageInXml messages related to the update
      */
     void newApplicationVersionAvailable(QString newVersion, std::queue<QString> messageInXml);
+
+    /**
+     * @brief Emitted when a new video entry was added into result data file.
+     * @param videoFolder
+     * @param dateTime
+     * @param videoLength
+     */
+    void resultDataSaved(QString videoFolder, QString dateTime, QString videoLength);
 };
 
 #endif // DATAMANAGER_H

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -24,6 +24,7 @@
 #include <QDomDocument>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QPolygon>
 #include <queue>
 
 /**
@@ -68,6 +69,14 @@ public:
 
     void saveResultData(QString dateTime, QString videoLength);
 
+    /**
+     * @brief Read detection area file.
+     * @return true on success, false on failure
+     */
+    bool readDetectionAreaFile();
+
+    QList<QPolygon*>& detectionArea();
+
 #ifndef _UNIT_TEST_
 private:
 #endif
@@ -78,6 +87,7 @@ private:
     QFile m_resultDataFile;  ///< result data file (XML)
     QDomDocument m_resultDataDomDocument;   ///< DOM representation of result data file
     QNetworkAccessManager* m_networkAccessManager;
+    QList<QPolygon*> m_detectionAreaPolygons; ///< detection area polygons (cameras not separated)
 
     /**
      * @brief Check that the folders for images, videos, and other files exist
@@ -134,6 +144,12 @@ signals:
      * @param videoLength
      */
     void resultDataSaved(QString videoFolder, QString dateTime, QString videoLength);
+
+    /**
+     * @brief Emitted on message broadcast.
+     * @param message
+     */
+    void messageBroadcasted(QString message);
 };
 
 #endif // DATAMANAGER_H

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -25,6 +25,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPolygon>
+#include <QList>
 #include <queue>
 
 /**

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -44,12 +44,6 @@ public:
     bool init();
 
     /**
-     * @brief Read result data from file into QDomDocument which can be got with resultDataDomDocument().
-     * @return true on success, false on failure
-     */
-    bool readResultDataFile();
-
-    /**
      * @brief Get pointer to DOM document representation of result data file.
      * @param readFile read the result data file, updating the DOM document
      *
@@ -99,6 +93,13 @@ private:
      * @brief Initiate download of bird classifier file.
      */
     void downloadBirdClassifierFile();
+
+public slots:
+    /**
+     * @brief Read result data from file into QDomDocument which can be got with resultDataDomDocument().
+     * @return true on success, false on failure
+     */
+    bool readResultDataFile();
 
 #ifndef _UNIT_TEST_
 private slots:

--- a/ufo-detector-engine/datamanager.h
+++ b/ufo-detector-engine/datamanager.h
@@ -1,0 +1,128 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DATAMANAGER_H
+#define DATAMANAGER_H
+
+#include "config.h"
+#include <QObject>
+#include <QDomDocument>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <queue>
+
+/**
+ * @brief Data manager class.
+ *
+ * @todo move result data saving from Recorder into this class
+ */
+class DataManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DataManager(Config* config, QObject *parent = 0);
+
+    /**
+     * @brief Initialize DataManger by checking folders etc.
+     * @return true on success, false on failure
+     */
+    bool init();
+
+    /**
+     * @brief Read result data from file into QDomDocument which can be got with resultDataDomDocument().
+     * @return true on success, false on failure
+     */
+    bool readResultDataFile();
+
+    /**
+     * @brief Get pointer to DOM document representation of result data file.
+     * @param readFile read the result data file, updating the DOM document
+     *
+     * Don't modify the document. Use removeVideo() to remove a video.
+     * Recorder class saves the videos and emits signal after it.
+     */
+    QDomDocument* resultDataDomDocument(bool readFile = false);
+
+    /**
+     * @brief Remove video from result data file and delete associated files.
+     * @param dateTime Date and time of video in format "YYYY-MM-DD--hh-mm-ss"
+     * @return true on success, false on failure
+     */
+    bool removeVideo(QString dateTime);
+
+    /**
+     * @brief Initiate update check for application and bird classifier data
+     *
+     * @todo move app update stuff into separate class (UpdateManager)
+     */
+    void checkForUpdates();
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+
+    Config* m_config;
+    bool m_initialized;
+    QString m_applicationVersion;   ///< app version   @todo move into UpdateManager
+    QFile m_resultDataFile;  ///< result data file (XML)
+    QDomDocument m_resultDataDomDocument;   ///< DOM representation of result data file
+    QNetworkAccessManager* m_networkAccessManager;
+
+    /**
+     * @brief Check that the folders for images, videos, and other files exist
+     */
+    bool checkFolders();
+
+    /**
+     * @brief Check detection area file and create if doesn't exist
+     */
+    bool checkDetectionAreaFile();
+
+    /**
+     * @brief Initiate download of bird classifier file.
+     */
+    void downloadBirdClassifierFile();
+
+#ifndef _UNIT_TEST_
+private slots:
+#else
+public slots:
+#endif
+
+    /**
+     * @brief Check for updates for application, bird classifier file.
+     * @param reply Update file from http://ufoid.net/version.xml
+     */
+    void handleUpdateReply(QNetworkReply* reply);
+
+    /**
+     * @brief Receive bird classifier file. Download initiated in init() method.
+     * @param reply Bird classifier file from http://ufoid.net/cascade.xml
+     */
+    void handleBirdClassifierReply(QNetworkReply* reply);
+
+signals:
+    /**
+     * @brief Emitted when new version of UFO Detector is available
+     * @param newVersion new version number
+     * @param messageInXml messages related to the update
+     */
+    void newApplicationVersionAvailable(QString newVersion, std::queue<QString> messageInXml);
+};
+
+#endif // DATAMANAGER_H

--- a/ufo-detector-engine/detectorstate.cpp
+++ b/ufo-detector-engine/detectorstate.cpp
@@ -11,7 +11,7 @@ DetectorState::DetectorState(QObject *parent, Recorder *rec) : QObject(parent), 
     map_result[BIRD] = {"Object was bird: removed video",false};
     map_result[MIN_POSITIVE_NOT_REACHED] = {"Minimum required positive detections not met: removed video",false};
     map_result[ALL_NEGATIVE] = {"All found objects negative: removed video",false};
-    int id = qRegisterMetaType<DetectorState::DetectionResult>();
+    qRegisterMetaType<DetectorState::DetectionResult>();
     connect(this,SIGNAL(foundDetectionResult(DetectorState::DetectionResult)),this,SLOT(handleResult(DetectorState::DetectionResult)));
 
 }

--- a/ufo-detector-engine/recorder.cpp
+++ b/ufo-detector-engine/recorder.cpp
@@ -263,7 +263,7 @@ void Recorder::readFrameThread()
     }
 }
 
-void Recorder::saveVideoThumbnailImage(Mat image, QString dateTime) {
+void Recorder::saveVideoThumbnailImage(Mat& image, QString dateTime) {
     Mat thumbnail = image.clone();
     cv::resize(thumbnail, thumbnail, m_thumbnailResolution, 0, 0, INTER_CUBIC);
     QString thumbnailFileName = m_resultVideoDirName + "/" + m_thumbnailDirName + "/" + dateTime + m_thumbnailExtension;

--- a/ufo-detector-engine/recorder.cpp
+++ b/ufo-detector-engine/recorder.cpp
@@ -140,6 +140,7 @@ void Recorder::recordThread(){
 
     if(m_willSaveVideo)
     {
+        saveVideoThumbnailImage(m_firstFrame, dateTime);
         saveResultData(dateTime, videoLength);
         if(!recordCodecIsFinal)
         {
@@ -264,12 +265,15 @@ void Recorder::readFrameThread()
     }
 }
 
+void Recorder::saveVideoThumbnailImage(Mat image, QString dateTime) {
+    Mat thumbnail = image.clone();
+    cv::resize(thumbnail, thumbnail, m_thumbnailResolution, 0, 0, INTER_CUBIC);
+    QString thumbnailFileName = m_resultVideoDirName + "/" + m_thumbnailDirName + "/" + dateTime + m_thumbnailExtension;
+    imwrite(thumbnailFileName.toStdString(), thumbnail);
+}
+
 void Recorder::saveResultData(QString dateTime, QString videoLength)
 {
-    cv::resize(m_firstFrame, m_firstFrame, m_thumbnailResolution, 0, 0, INTER_CUBIC);
-    QString thumbnail = m_resultVideoDirName + "/" + m_thumbnailDirName + "/" + dateTime + m_thumbnailExtension;
-    imwrite(thumbnail.toStdString(), m_firstFrame);
-
     /// @todo create root element here if it doesn't exist
     QDomElement node = m_resultDataDomDocument.createElement("Video");
     node.setAttribute("Pathname", m_resultVideoDirName);

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -58,7 +58,7 @@ class Recorder : public QObject {
 Q_OBJECT
 
 public:
-    explicit Recorder(Camera* cameraPtr = 0, Config* configPtr = 0);
+    explicit Recorder(Camera* cameraPtr, Config* configPtr);
     void startRecording(cv::Mat &firstFrame);
     void stopRecording(bool willSaveVideo);
     void setRectangle(cv::Rect &r, bool isRed);

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "camera.h"
 #include "videobuffer.h"
+#include "datamanager.h"
 #include <QDomDocument>
 #include <QFile>
 #include <QObject>
@@ -58,7 +59,7 @@ class Recorder : public QObject {
 Q_OBJECT
 
 public:
-    explicit Recorder(Camera* cameraPtr, Config* configPtr);
+    explicit Recorder(Camera* cameraPtr, Config* configPtr, DataManager* dataManager);
     void startRecording(cv::Mat &firstFrame);
     void stopRecording(bool willSaveVideo);
     void setRectangle(cv::Rect &r, bool isRed);
@@ -70,6 +71,7 @@ private:
 
     Camera* m_camera;
     Config* m_config;
+    DataManager* m_dataManager;
     cv::VideoWriter m_videoWriter;
     cv::Mat m_firstFrame;
     VideoBuffer* m_videoBuffer;
@@ -94,10 +96,6 @@ private:
     std::vector<QProcess*> m_encoderProcesses;
     std::vector<QString> m_tempVideoFiles;
 
-    QDomDocument m_resultDataDomDocument;
-    QFile m_resultDataFile;
-    QDomElement m_resultDataRootElement;
-
     void recordThread();
 
     /**
@@ -114,19 +112,6 @@ private:
      */
     void saveVideoThumbnailImage(Mat image, QString dateTime);
 
-    /**
-     * @brief Save information about the video to result data file.
-     * Emits resultDataSaved() signal.
-     * @param dateTime format: yyyy-MM-dd--hh-mm-ss
-     * @param videoLength format: mm:ss
-     *
-     * @todo move saveResultData() into DataManager
-     */
-    void saveResultData(QString dateTime, QString videoLength);
-
-public slots:
-    void reloadResultDataFile();
-
 #ifndef _UNIT_TEST_
 private slots:
 #endif
@@ -142,7 +127,6 @@ private slots:
     void onVideoEncodingFinished();
 
 signals:
-    void resultDataSaved(QString file, QString date, QString length);
     void recordingStarted();
     void recordingFinished();
     void videoEncodingRequested(QString tempVideoName, QString targetVideoName);

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -112,6 +112,8 @@ private:
      * Emits resultDataSaved() signal.
      * @param dateTime format: yyyy-MM-dd--hh-mm-ss
      * @param videoLength format: mm:ss
+     *
+     * @todo move saveResultData() into DataManager
      */
     void saveResultData(QString dateTime, QString videoLength);
 

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -110,7 +110,7 @@ private:
      * @param image
      * @param dateTime
      */
-    void saveVideoThumbnailImage(Mat image, QString dateTime);
+    void saveVideoThumbnailImage(Mat& image, QString dateTime);
 
 #ifndef _UNIT_TEST_
 private slots:

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -108,6 +108,13 @@ private:
     void readFrameThread();
 
     /**
+     * @brief Save video thumbnail image.
+     * @param image
+     * @param dateTime
+     */
+    void saveVideoThumbnailImage(Mat image, QString dateTime);
+
+    /**
      * @brief Save information about the video to result data file.
      * Emits resultDataSaved() signal.
      * @param dateTime format: yyyy-MM-dd--hh-mm-ss

--- a/ufo-detector-engine/recorder.h
+++ b/ufo-detector-engine/recorder.h
@@ -114,6 +114,8 @@ private:
 
 #ifndef _UNIT_TEST_
 private slots:
+#else
+public slots:
 #endif
     /**
      * @brief Creates a new QProcess that encodes the temporary raw video with ffmpeg/avconv.

--- a/ufo-detector-engine/test/README.txt
+++ b/ufo-detector-engine/test/README.txt
@@ -1,0 +1,6 @@
+
+Running test suite:
+
+qmake
+make check
+

--- a/ufo-detector-engine/test/mock/mockRecorder.cpp
+++ b/ufo-detector-engine/test/mock/mockRecorder.cpp
@@ -22,9 +22,10 @@ int mockRecorderStartCount;
 int mockRecorderStopCount;
 
 
-Recorder::Recorder(Camera* cameraPtr, Config* configPtr) {
+Recorder::Recorder(Camera* cameraPtr, Config* configPtr, DataManager* dataManager) {
     Q_UNUSED(cameraPtr);
     Q_UNUSED(configPtr);
+    Q_UNUSED(dataManager);
 }
 
 void Recorder::startRecording(cv::Mat &firstFrame) {
@@ -42,9 +43,6 @@ void Recorder::stopRecording(bool willSaveVideo) {
 void Recorder::setRectangle(cv::Rect &r, bool isRed) {
     Q_UNUSED(r);
     Q_UNUSED(isRed);
-}
-
-void Recorder::reloadResultDataFile() {
 }
 
 void Recorder::startEncodingVideo(QString tempVideoFileName, QString targetVideoFileName) {

--- a/ufo-detector-engine/test/mock/mockcamera.cpp
+++ b/ufo-detector-engine/test/mock/mockcamera.cpp
@@ -93,8 +93,6 @@ void startCameraFromVideo(QFile* videoFile){
 
     }
     isReadingVideo = false;
-
-
 }
 
 
@@ -125,10 +123,6 @@ cv::Mat Camera::getWebcamFrame() {
         mockCamera_blockerMutex.unlock();
     }
     return mockCameraNextFrame;
-}
-
-void Camera::stopReadingWebcam() {
-
 }
 
 bool Camera::isWebcamOpen() {

--- a/ufo-detector-engine/test/mock/mockconfig.cpp
+++ b/ufo-detector-engine/test/mock/mockconfig.cpp
@@ -101,6 +101,10 @@ QString testResourceFolder(){
     return resources.path();
 }
 
+int Config::classifierVersion() {
+    return 1;
+}
+
 QString Config::resultDataFile() {
     return "./resultdata.xml";
 }
@@ -202,5 +206,9 @@ void Config::setSaveResultImages(bool save) {
 
 void Config::setUserTokenAtUfoId(QString token) {
     Q_UNUSED(token);
+}
+
+void Config::setClassifierVersion(int version) {
+    Q_UNUSED(version);
 }
 

--- a/ufo-detector-engine/test/mock/mockdatamanager.cpp
+++ b/ufo-detector-engine/test/mock/mockdatamanager.cpp
@@ -38,3 +38,12 @@ void DataManager::handleUpdateReply(QNetworkReply *reply) {
 void DataManager::handleBirdClassifierReply(QNetworkReply *reply) {
     Q_UNUSED(reply);
 }
+
+bool DataManager::readDetectionAreaFile(bool clipToCamera) {
+    Q_UNUSED(clipToCamera);
+    return true;
+}
+
+QList<QPolygon*>& DataManager::detectionArea() {
+    return m_detectionAreaPolygons;
+}

--- a/ufo-detector-engine/test/mock/mockdatamanager.cpp
+++ b/ufo-detector-engine/test/mock/mockdatamanager.cpp
@@ -1,0 +1,35 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "datamanager.h"
+
+DataManager::DataManager(Config* config, QObject* parent) : QObject(parent) {
+    m_config = config;
+}
+
+bool DataManager::readResultDataFile() {
+    return true;
+}
+
+void DataManager::handleUpdateReply(QNetworkReply *reply) {
+    Q_UNUSED(reply);
+}
+
+void DataManager::handleBirdClassifierReply(QNetworkReply *reply) {
+    Q_UNUSED(reply);
+}

--- a/ufo-detector-engine/test/mock/mockvideobuffer.cpp
+++ b/ufo-detector-engine/test/mock/mockvideobuffer.cpp
@@ -16,25 +16,33 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "datamanager.h"
+#include "videobuffer.h"
 
-DataManager::DataManager(Config* config, QObject* parent) : QObject(parent) {
-    m_config = config;
+VideoBuffer::VideoBuffer(int capacity, QObject *parent) : QObject(parent) {
+    m_capacity = capacity;
 }
 
-bool DataManager::readResultDataFile() {
+BufferedVideoFrame* VideoBuffer::waitNextFrame() {
+    if (!m_buffer.isEmpty()) {
+        return m_buffer.takeFirst();
+    }
+    return NULL;
+}
+
+int VideoBuffer::count() {
+    return 0;
+}
+
+int VideoBuffer::capacity() {
+    return m_capacity;
+}
+
+bool VideoBuffer::pushFrame(BufferedVideoFrame *frame) {
+    m_buffer.append(frame);
     return true;
 }
 
-void DataManager::saveResultData(QString dateTime, QString videoLength) {
-    Q_UNUSED(dateTime);
-    Q_UNUSED(videoLength);
+void VideoBuffer::stopWait() {
 }
 
-void DataManager::handleUpdateReply(QNetworkReply *reply) {
-    Q_UNUSED(reply);
-}
 
-void DataManager::handleBirdClassifierReply(QNetworkReply *reply) {
-    Q_UNUSED(reply);
-}

--- a/ufo-detector-engine/test/testActualDetector/testActualDetector.cpp
+++ b/ufo-detector-engine/test/testActualDetector/testActualDetector.cpp
@@ -19,7 +19,7 @@
 #include "actualdetector.h"
 #include "config.h"
 #include "camera.h"
-#include "mainwindow.h"
+#include "datamanager.h"
 #include <QString>
 #include <QtTest>
 #include <QCoreApplication>
@@ -64,7 +64,7 @@ private:
     ActualDetector* m_actualDetector;
     Config* m_config;
     Camera* m_camera;
-    MainWindow* m_mainWindow;
+    DataManager* m_dataManager;
 
     // test thread to consume camera frames
     std::thread* m_cameraFrameConsumerThread;
@@ -88,6 +88,7 @@ TestActualDetector::TestActualDetector() {
     m_actualDetector = NULL;
     m_config = NULL;
     m_camera = NULL;
+    m_dataManager = NULL;
     m_cameraFrameConsumerThread = NULL;
     m_cameraFramesConsumed = 0;
     m_consumeCameraFrames = false;
@@ -101,8 +102,9 @@ void TestActualDetector::initTestCase() {
     QVERIFY(NULL != m_config);
     m_camera = new Camera(m_config->cameraIndex(), m_config->cameraWidth(), m_config->cameraHeight());
     QVERIFY(NULL != m_camera);
-    m_mainWindow = new MainWindow(0,m_camera,m_config);
-    m_actualDetector = new ActualDetector(m_camera, m_config, m_mainWindow);
+    m_dataManager = new DataManager(m_config);
+    QVERIFY(NULL != m_dataManager);
+    m_actualDetector = new ActualDetector(m_camera, m_config, m_dataManager);
     QVERIFY(NULL != m_actualDetector);
     m_cameraFps = 25;
 
@@ -114,9 +116,9 @@ void TestActualDetector::initTestCase() {
 
 void TestActualDetector::cleanupTestCase() {
     m_actualDetector->deleteLater();
+    m_dataManager->deleteLater();
     m_camera->deleteLater();
     m_config->deleteLater();
-    m_mainWindow->deleteLater();
 }
 
 void TestActualDetector::cameraFrameConsumerThreadFunc() {

--- a/ufo-detector-engine/test/testActualDetector/testActualDetector.cpp
+++ b/ufo-detector-engine/test/testActualDetector/testActualDetector.cpp
@@ -112,6 +112,11 @@ void TestActualDetector::initTestCase() {
     if (!detectionAreaFile.exists()) {
         makeDetectionAreaFile();
     }
+    QPolygon* detectionArea = new QPolygon();
+    *detectionArea << QPoint(0, 0) << QPoint(0, m_config->cameraHeight() - 1)
+                  << QPoint(m_config->cameraWidth() - 1, m_config->cameraHeight() - 1)
+                  << QPoint(m_config->cameraWidth() - 1, 0);
+    m_dataManager->m_detectionAreaPolygons << detectionArea;
 }
 
 void TestActualDetector::cleanupTestCase() {
@@ -406,14 +411,20 @@ void TestActualDetector::makeDetectionAreaFile() {
     QFile detectionAreaFile(m_config->detectionAreaFile());
     QVERIFY(detectionAreaFile.open(QFile::ReadWrite));
     QTextStream out(&detectionAreaFile);
-    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-    out << "<UFOID>\n";
-    for (int y = 0; y < m_config->cameraHeight(); y++) {
-        for (int x = 0; x < m_config->cameraWidth(); x++) {
-            out << "\t<point x=\"" << x << "\" y=\"" << y << "\"/>\n";
-        }
-    }
-    out << "</UFOID>";
+    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << endl;
+    out << "<detectionarealist>" << endl;
+    out << "<detectionarea>" << endl;
+    out << "<camera id=\"" << m_config->cameraIndex() << "\" width=\""
+        << m_config->cameraWidth() << "\" height=\"" << m_config->cameraHeight()
+        << "\"/>" << endl;
+    out << "<polygon>" << endl;
+    out << "<point x=\"0\" y=\"0\"/>" << endl;
+    out << "<point x=\"0\" y=\"" << m_config->cameraHeight() << "\"/>" << endl;
+    out << "<point x=\"" << m_config->cameraWidth() << "\" y=\"" << m_config->cameraHeight() << "\"/>" << endl;
+    out << "<point x=\"" << m_config->cameraWidth() << "\" y=\"0\"/>" << endl;
+    out << "</polygon>" << endl;
+    out << "</detectionarea>" << endl;
+    out << "</detectionarealist>" << endl;
     detectionAreaFile.close();
 }
 

--- a/ufo-detector-engine/test/testActualDetector/testActualDetector.pro
+++ b/ufo-detector-engine/test/testActualDetector/testActualDetector.pro
@@ -7,8 +7,8 @@
 QT       += widgets testlib xml network
 
 TARGET = testActualDetector
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testActualDetector/testActualDetector.pro
+++ b/ufo-detector-engine/test/testActualDetector/testActualDetector.pro
@@ -32,7 +32,6 @@ SOURCES += \
     ../mock/mockconfig.cpp \
     ../mock/mockcamera.cpp \
     ../mock/mockRecorder.cpp \
-    ../mock/mockMainWindow.cpp \
     ../../Ctracker.cpp \
     ../../Detector.cpp \
     ../../Kalman.cpp \
@@ -40,7 +39,8 @@ SOURCES += \
     ../mock/mockVideoCodecSupportInfo.cpp \
     testActualDetector.cpp\
     ../../planechecker.cpp \
-   ../../detectorstate.cpp
+   ../../detectorstate.cpp \
+    ../mock/mockdatamanager.cpp
 
 
 HEADERS += ../../actualdetector.h \
@@ -54,6 +54,6 @@ HEADERS += ../../actualdetector.h \
     ../../videocodecsupportinfo.h \
     ../../planechecker.h \
     ../../detectorstate.h \
-    ../../../ui-qt/mainwindow.h
+    ../../datamanager.h
 
 

--- a/ufo-detector-engine/test/testCameraInfo/testCameraInfo.pro
+++ b/ufo-detector-engine/test/testCameraInfo/testCameraInfo.pro
@@ -9,8 +9,8 @@ QT       += testlib
 QT       -= gui
 
 TARGET = testcamerainfo
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testConfig/testConfig.pro
+++ b/ufo-detector-engine/test/testConfig/testConfig.pro
@@ -9,8 +9,8 @@ QT       += testlib core widgets
 #QT       -= gui
 
 TARGET = testconfig
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testDataManager/testDataManager.pro
+++ b/ufo-detector-engine/test/testDataManager/testDataManager.pro
@@ -9,8 +9,8 @@ QT       += network testlib xml widgets
 QT       -= gui
 
 TARGET = testdatamanager
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testDataManager/testDataManager.pro
+++ b/ufo-detector-engine/test/testDataManager/testDataManager.pro
@@ -1,0 +1,30 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2017-04-09T20:29:29
+#
+#-------------------------------------------------
+
+QT       += network testlib xml widgets
+
+QT       -= gui
+
+TARGET = testdatamanager
+CONFIG   += console
+CONFIG   -= app_bundle
+
+TEMPLATE = app
+
+DEFINES += SRCDIR=\\\"$$PWD/\\\" \
+    _UNIT_TEST_
+
+INCLUDEPATH += ../../ \
+    ../mock
+
+SOURCES += testdatamanager.cpp \
+    ../../datamanager.cpp \
+    ../mock/mockconfig.cpp \
+    ../mock/mockVideoCodecSupportInfo.cpp
+
+HEADERS += ../../datamanager.h \
+    ../../config.h \
+    ../../videocodecsupportinfo.h

--- a/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
+++ b/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
@@ -45,6 +45,8 @@ private Q_SLOTS:
     void checkFolders();
     void checkDetectionAreaFile();
     void readResultDataFile();
+    void readDetectionAreaFile();
+    void detectionArea();
 
 public slots:
     void onResultDataSaved(QString dirName, QString dateTime, QString videoLength);
@@ -173,6 +175,14 @@ void TestDataManager::checkDetectionAreaFile() {
 
 void TestDataManager::readResultDataFile() {
     QSKIP("TODO");
+}
+
+void TestDataManager::readDetectionAreaFile() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::detectionArea() {
+    QVERIFY(m_dataManager->detectionArea() == m_dataManager->m_detectionAreaPolygons);
 }
 
 QTEST_APPLESS_MAIN(TestDataManager)

--- a/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
+++ b/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
@@ -47,6 +47,7 @@ private Q_SLOTS:
     void readResultDataFile();
     void readDetectionAreaFile();
     void detectionArea();
+    void resetDetectionAreaFile();
 
 public slots:
     void onResultDataSaved(QString dirName, QString dateTime, QString videoLength);
@@ -183,6 +184,10 @@ void TestDataManager::readDetectionAreaFile() {
 
 void TestDataManager::detectionArea() {
     QVERIFY(m_dataManager->detectionArea() == m_dataManager->m_detectionAreaPolygons);
+}
+
+void TestDataManager::resetDetectionAreaFile() {
+    QSKIP("TODO");
 }
 
 QTEST_APPLESS_MAIN(TestDataManager)

--- a/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
+++ b/ufo-detector-engine/test/testDataManager/testdatamanager.cpp
@@ -1,0 +1,180 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "datamanager.h"
+#include <QString>
+#include <QtTest>
+#include <QDomDocument>
+#include <QDomNode>
+
+class TestDataManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestDataManager();
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void init();
+    void cleanup();
+
+    void constructor();
+    void initDataManager();
+    void resultDataDomDocument();
+    void removeVideo();
+    void saveResultData();
+    void checkFolders();
+    void checkDetectionAreaFile();
+    void readResultDataFile();
+
+public slots:
+    void onResultDataSaved(QString dirName, QString dateTime, QString videoLength);
+
+private:
+    QFile m_resultDataFile;
+    int m_resultDataSavedCounter;
+    Config* m_config;
+    DataManager* m_dataManager;
+};
+
+TestDataManager::TestDataManager()
+{
+}
+
+void TestDataManager::initTestCase() {
+    // create result data file here because it is created in MainWindow and not by Recorder
+    m_resultDataFile.setFileName(m_config->resultDataFile());
+    if (m_resultDataFile.exists()) {
+        m_resultDataFile.remove();
+    }
+    QDomDocument resultDataDom;
+    QVERIFY(!m_resultDataFile.exists());
+    QVERIFY(m_resultDataFile.open(QFile::ReadWrite));
+    QTextStream stream(&m_resultDataFile);
+    QDomElement ufoidElement = resultDataDom.createElement("UFOID");
+    resultDataDom.appendChild(ufoidElement);
+    stream << resultDataDom.toString();
+    m_resultDataFile.flush();
+    m_resultDataFile.close();
+    QVERIFY(m_resultDataFile.exists());
+    m_config = new Config();
+    m_dataManager = new DataManager(m_config);
+}
+
+void TestDataManager::cleanupTestCase() {
+    QVERIFY(m_resultDataFile.remove());
+    QVERIFY(!m_resultDataFile.exists());
+    QDir videoDir(m_config->resultVideoDir());
+    QVERIFY(videoDir.removeRecursively());
+    QVERIFY(!videoDir.exists());
+    m_dataManager->deleteLater();
+    m_config->deleteLater();
+}
+
+void TestDataManager::init() {
+    m_resultDataSavedCounter = 0;
+}
+
+void TestDataManager::cleanup() {
+}
+
+void TestDataManager::onResultDataSaved(QString dirName, QString dateTime, QString videoLength) {
+    Q_UNUSED(dirName);
+    Q_UNUSED(dateTime);
+    Q_UNUSED(videoLength);
+    m_resultDataSavedCounter++;
+}
+
+void TestDataManager::constructor()
+{
+    QVERIFY(m_config == m_dataManager->m_config);
+    QVERIFY(false == m_dataManager->m_initialized);
+    QVERIFY(APPLICATION_VERSION == m_dataManager->m_applicationVersion);
+}
+
+void TestDataManager::initDataManager() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::resultDataDomDocument() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::removeVideo() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::saveResultData() {
+    QString dateTime = "2017-04-10--12-00-00";
+    QString videoLength = "01:02";
+    QDomDocument resultDataDom;
+    QDomElement videoEntry;
+    connect(m_dataManager, SIGNAL(resultDataSaved(QString,QString,QString)),
+            this, SLOT(onResultDataSaved(QString,QString,QString)));
+
+    // case: write one entry
+
+    // check result data file doesn't have any other content than the main tag
+    QVERIFY(m_resultDataFile.open(QFile::ReadOnly));
+    QVERIFY(resultDataDom.setContent(m_resultDataFile.readAll()));
+    m_resultDataFile.close();
+    QVERIFY(resultDataDom.firstChild().childNodes().isEmpty());
+    resultDataDom.clear();
+
+    QCOMPARE(m_resultDataSavedCounter, 0);
+
+    m_dataManager->init();
+
+    m_dataManager->saveResultData(dateTime, videoLength);
+
+    QCOMPARE(m_resultDataSavedCounter, 1);
+    QVERIFY(!m_dataManager->m_resultDataFile.isOpen());
+    // check content of result data file
+    QVERIFY(m_resultDataFile.open(QFile::ReadOnly));
+    QVERIFY(resultDataDom.setContent(m_resultDataFile.readAll()));
+    m_resultDataFile.close();
+    QVERIFY(!resultDataDom.firstChild().childNodes().isEmpty());
+    QCOMPARE(resultDataDom.firstChild().childNodes().count(), 1);
+    videoEntry = resultDataDom.firstChild().childNodes().at(0).toElement();
+    QCOMPARE(videoEntry.nodeName(), QString("Video"));
+    QCOMPARE(videoEntry.attributes().length(), 3);
+    QCOMPARE(videoEntry.attribute("Pathname"), m_config->resultVideoDir());
+    QCOMPARE(videoEntry.attribute("Length"), videoLength);
+    QCOMPARE(videoEntry.attribute("DateTime"), dateTime);
+    resultDataDom.clear();
+}
+
+void TestDataManager::checkFolders() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::checkDetectionAreaFile() {
+    QSKIP("TODO");
+}
+
+void TestDataManager::readResultDataFile() {
+    QSKIP("TODO");
+}
+
+QTEST_APPLESS_MAIN(TestDataManager)
+
+#include "testdatamanager.moc"

--- a/ufo-detector-engine/test/testRecorder/testRecorder.pro
+++ b/ufo-detector-engine/test/testRecorder/testRecorder.pro
@@ -7,8 +7,8 @@
 QT       += testlib core xml widgets network
 
 TARGET = testrecorder
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testRecorder/testRecorder.pro
+++ b/ufo-detector-engine/test/testRecorder/testRecorder.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += testlib core xml widgets
+QT       += testlib core xml widgets network
 
 TARGET = testrecorder
 CONFIG   += console
@@ -28,6 +28,8 @@ INCLUDEPATH += . \
 SOURCES += testrecorder.cpp \
     ../mock/mockcamera.cpp \
     ../mock/mockconfig.cpp \
+    ../mock/mockdatamanager.cpp \
+    ../mock/mockvideobuffer.cpp \
     ../../videocodecsupportinfo.cpp \
     ../../recorder.cpp \
     ../../camerainfo.cpp
@@ -36,5 +38,7 @@ HEADERS += ../../recorder.h \
     ../../config.h \
     ../../videocodecsupportinfo.h \
     ../../camera.h \
-    ../../camerainfo.h
+    ../../camerainfo.h \
+    ../../datamanager.h \
+    ../../videobuffer.h
 

--- a/ufo-detector-engine/test/testRecorder/testrecorder.cpp
+++ b/ufo-detector-engine/test/testRecorder/testrecorder.cpp
@@ -56,6 +56,8 @@ private Q_SLOTS:
      */
     void mockCamera();
 
+    void saveVideoThumbnailImage();
+
 private:
     Recorder* m_recorder;
     Config* m_config;
@@ -275,6 +277,19 @@ void TestRecorder::videoCodecs()
     }
     // Recorder has modified the next frame of mock Camera so clean it
     mockCameraNextFrame = cv::Mat();
+}
+
+void TestRecorder::saveVideoThumbnailImage() {
+    QString dateTime = "2017-04-10--12-00-00";
+    QString thumbnailFileName = m_config->resultVideoDir() + "/thumbnails/" + dateTime + ".jpg";
+    QFile thumbnailFile(thumbnailFileName);
+    Mat thumbnailImage(100, 200, CV_8UC3);
+
+    m_recorder->saveVideoThumbnailImage(thumbnailImage, dateTime);
+
+    QVERIFY(thumbnailFile.exists());
+    QVERIFY(thumbnailFile.remove());
+    QVERIFY(!thumbnailFile.exists());
 }
 
 void TestRecorder::fourccToStr(int fourcc, char str[5]) {

--- a/ufo-detector-engine/test/testRecorder/testrecorder.cpp
+++ b/ufo-detector-engine/test/testRecorder/testrecorder.cpp
@@ -17,9 +17,9 @@
  */
 
 #include "recorder.h"
-//#include "actualdetector.h"
 #include "camera.h"
 #include "config.h"
+#include "datamanager.h"
 #include <QtTest>
 #include <QString>
 #include <QFile>
@@ -45,7 +45,6 @@ private Q_SLOTS:
     void initTestCase();
     void cleanupTestCase();
     void constructor();
-    void saveResultData();
 
     /*
      * Go through supported codecs and check Recorder will encode video with correct codec.
@@ -61,8 +60,7 @@ private:
     Recorder* m_recorder;
     Config* m_config;
     Camera* m_camera;
-    QFile m_resultDataFile;
-    int m_resultDataSavedCounter;
+    DataManager* m_dataManager;
     int m_requestEncodingCounter;
     QString m_requestEncodingTempFileName;
     QString m_requestEncodingTargetFileName;
@@ -70,60 +68,27 @@ private:
     void fourccToStr(int fourcc, char str[5]);
 
 private slots:
-    void onResultDataSaved(QString fileName, QString dateTime, QString videoLength);
     void onVideoEncodingRequested(QString tempFileName, QString targetFileName);
 };
 
 TestRecorder::TestRecorder() {
-    m_resultDataSavedCounter = 0;
     m_requestEncodingCounter = 0;
 }
 
 TestRecorder::~TestRecorder() {
 }
 
-void TestRecorder::onResultDataSaved(QString fileName, QString dateTime, QString videoLength) {
-    Q_UNUSED(fileName);
-    Q_UNUSED(dateTime);
-    Q_UNUSED(videoLength);
-    m_resultDataSavedCounter++;
-}
-
-void TestRecorder::onVideoEncodingRequested(QString tempFileName, QString targetFileName) {
-    m_requestEncodingTempFileName = tempFileName;
-    m_requestEncodingTargetFileName = targetFileName;
-    m_requestEncodingCounter++;
-}
-
 void TestRecorder::initTestCase() {
     m_config = new Config();
-
-    // create result data file here because it is created in MainWindow and not by Recorder
-    m_resultDataFile.setFileName(m_config->resultDataFile());
-    if (m_resultDataFile.exists()) {
-        m_resultDataFile.remove();
-    }
-    QDomDocument resultDataDom;
-    QVERIFY(!m_resultDataFile.exists());
-    QVERIFY(m_resultDataFile.open(QFile::ReadWrite));
-    QTextStream stream(&m_resultDataFile);
-    QDomElement ufoidElement = resultDataDom.createElement("UFOID");
-    resultDataDom.appendChild(ufoidElement);
-    stream << resultDataDom.toString();
-    m_resultDataFile.flush();
-    m_resultDataFile.close();
-    QVERIFY(m_resultDataFile.exists());
-
     m_camera = new Camera(m_config->cameraIndex(), m_config->cameraWidth(), m_config->cameraHeight());
-    m_recorder = new Recorder(m_camera, m_config);
+    m_dataManager = new DataManager(m_config);
+    m_recorder = new Recorder(m_camera, m_config, m_dataManager);
 }
 
 void TestRecorder::cleanupTestCase() {
     m_recorder->deleteLater();
     m_camera->deleteLater();
     m_config->deleteLater();
-    QVERIFY(m_resultDataFile.remove());
-    QVERIFY(!m_resultDataFile.exists());
     QDir videoDir(m_config->resultVideoDir());
     QVERIFY(videoDir.removeRecursively());
     QVERIFY(!videoDir.exists());
@@ -150,63 +115,15 @@ void TestRecorder::constructor() {
     QCOMPARE(m_recorder->m_objectNegativeColor, cv::Scalar(0, 0, 255));
     QCOMPARE(m_recorder->m_objectRectangleColor, m_recorder->m_objectPositiveColor);
 
-    QCOMPARE(m_recorder->m_resultDataFile.fileName(), m_config->resultDataFile());
     QCOMPARE(m_recorder->m_resultVideoDirName, m_config->resultVideoDir());
     QCOMPARE(m_recorder->m_videoFileExtension, QString(".avi"));
     QCOMPARE(m_recorder->m_thumbnailExtension, QString(".jpg"));
     QCOMPARE(m_recorder->m_thumbnailDirName, QString("thumbnails"));
-    QFile resultDataFile(m_config->resultDataFile());
-    QVERIFY(resultDataFile.exists());
     QDir thumbDir(m_config->resultVideoDir() + "/" + m_recorder->m_thumbnailDirName);
     QVERIFY(thumbDir.exists());
 
     QVERIFY(!m_recorder->m_willSaveVideo);
     QVERIFY(!m_recorder->m_recording);
-}
-
-void TestRecorder::saveResultData() {
-    QString dateTime = "2016-05-22--12-00-00";
-    QString videoLength = "01:02";
-    QDomDocument resultDataDom;
-    QDomElement videoEntry;
-    connect(m_recorder, SIGNAL(resultDataSaved(QString,QString,QString)),
-            this, SLOT(onResultDataSaved(QString,QString,QString)));
-
-    // case: write one entry
-
-    // check result data file doesn't have any other content than the main tag
-    QVERIFY(m_resultDataFile.open(QFile::ReadOnly));
-    QVERIFY(resultDataDom.setContent(m_resultDataFile.readAll()));
-    m_resultDataFile.close();
-    QVERIFY(resultDataDom.firstChild().childNodes().isEmpty());
-    resultDataDom.clear();
-
-    QCOMPARE(m_resultDataSavedCounter, 0);
-    m_recorder->m_firstFrame = cv::Mat(cv::Size(m_config->cameraWidth(), m_config->cameraWidth()), CV_8UC3);
-
-    m_recorder->saveResultData(dateTime, videoLength);
-
-    QCOMPARE(m_resultDataSavedCounter, 1);
-    QVERIFY(!m_recorder->m_resultDataFile.isOpen());
-    // check content of result data file
-    QVERIFY(m_resultDataFile.open(QFile::ReadOnly));
-    QVERIFY(resultDataDom.setContent(m_resultDataFile.readAll()));
-    m_resultDataFile.close();
-    QVERIFY(!resultDataDom.firstChild().childNodes().isEmpty());
-    QCOMPARE(resultDataDom.firstChild().childNodes().count(), 1);
-    videoEntry = resultDataDom.firstChild().childNodes().at(0).toElement();
-    QCOMPARE(videoEntry.nodeName(), QString("Video"));
-    QCOMPARE(videoEntry.attributes().length(), 3);
-    QCOMPARE(videoEntry.attribute("Pathname"), m_config->resultVideoDir());
-    QCOMPARE(videoEntry.attribute("Length"), videoLength);
-    QCOMPARE(videoEntry.attribute("DateTime"), dateTime);
-    resultDataDom.clear();
-    // check thumbnail
-    QString thumbnailFileName = m_config->resultVideoDir() + "/thumbnails/" + dateTime + ".jpg";
-    QFile thumbnailFile(thumbnailFileName);
-    QVERIFY(thumbnailFile.exists());
-    QVERIFY(thumbnailFile.remove());
-    QVERIFY(!thumbnailFile.exists());
 }
 
 void TestRecorder::mockCamera() {
@@ -279,8 +196,6 @@ void TestRecorder::videoCodecs()
         if (m_recorder) {
             m_recorder->disconnect(m_recorder, SIGNAL(videoEncodingRequested(QString,QString)), this,
                                    SLOT(onVideoEncodingRequested(QString,QString)));
-            m_recorder->disconnect(m_recorder, SIGNAL(resultDataSaved(QString,QString,QString)), this,
-                                   SLOT(onResultDataSaved(QString,QString,QString)));
             m_recorder->deleteLater();
         }
 
@@ -295,11 +210,9 @@ void TestRecorder::videoCodecs()
 
         qDebug() << "=== Testing codec" << codecStr << "===";
 
-        m_recorder = new Recorder(m_camera, m_config);
+        m_recorder = new Recorder(m_camera, m_config, m_dataManager);
         connect(m_recorder, SIGNAL(videoEncodingRequested(QString,QString)), this,
                 SLOT(onVideoEncodingRequested(QString,QString)));
-        connect(m_recorder, SIGNAL(resultDataSaved(QString,QString,QString)), this,
-                SLOT(onResultDataSaved(QString,QString,QString)));
 
         cv::Mat firstFrame = cv::Mat(m_config->cameraHeight(), m_config->cameraWidth(), CV_8UC3);
         // Recorder will be getting mockCameraNextFrame
@@ -318,7 +231,6 @@ void TestRecorder::videoCodecs()
         m_requestEncodingTempFileName = "";
         m_requestEncodingTargetFileName = "";
         m_requestEncodingCounter = 0;
-        m_resultDataSavedCounter = 0;
 
         m_recorder->startRecording(firstFrame);
         QTest::qWait(100);
@@ -338,7 +250,6 @@ void TestRecorder::videoCodecs()
         } else {
             QTest::qWait(500);
         }
-        QCOMPARE(m_resultDataSavedCounter, 1);
 
         QVERIFY(!tempFile.exists());
         QVERIFY(resultVideoFile.exists());
@@ -371,6 +282,12 @@ void TestRecorder::fourccToStr(int fourcc, char str[5]) {
         str[i] = (fourcc >> (i*8)) & 0xFF;
     }
     str[4] = '\0';
+}
+
+void TestRecorder::onVideoEncodingRequested(QString tempFileName, QString targetFileName) {
+    m_requestEncodingTempFileName = tempFileName;
+    m_requestEncodingTargetFileName = targetFileName;
+    m_requestEncodingCounter++;
 }
 
 QTEST_MAIN(TestRecorder)

--- a/ufo-detector-engine/test/testVideoBuffer/testVideoBuffer.pro
+++ b/ufo-detector-engine/test/testVideoBuffer/testVideoBuffer.pro
@@ -9,8 +9,8 @@ QT       += testlib
 QT       -= gui
 
 TARGET = testvideobuffer
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
+++ b/ufo-detector-engine/test/testVideoCodecSupportInfo/testVideoCodecSupportInfo.pro
@@ -9,8 +9,8 @@ QT       += testlib core widgets
 QT       -= gui
 
 TARGET = testVideoCodecSupportInfo
-CONFIG   += console
-CONFIG   -= app_bundle
+CONFIG += console testcase
+CONFIG -= app_bundle
 
 TEMPLATE = app
 

--- a/ufo-detector-engine/test/testsuite.pro
+++ b/ufo-detector-engine/test/testsuite.pro
@@ -10,8 +10,32 @@ SUBDIRS = \
     testRecorder \
     testActualDetector \
     testVideoCodecSupportInfo \
-    testVideoBuffer
-
-
+    testVideoBuffer \
+    testDataManager
 
 LIBS += -lgcov
+
+# borrowed from https://github.com/KDAB/KDSoap/blob/master/unittests/unittests.pro (project is also LGPL)
+test.target=test
+unix:!macx {
+    LIB_PATH=$${TOP_BUILD_DIR}/lib:\$\$LD_LIBRARY_PATH
+    test.commands=for d in $${SUBDIRS}; do origdir="\$$PWD" && cd "\$$d" && LD_LIBRARY_PATH=$$LIB_PATH && $(MAKE) test && cd "\$$origdir" || exit 1; done
+}
+unix:macx {
+    LIB_PATH=$${TOP_BUILD_DIR}/lib:\$\$DYLD_LIBRARY_PATH
+    test.commands=for d in $${SUBDIRS}; do ( cd "\$$d" && export DYLD_LIBRARY_PATH=$$LIB_PATH && $(MAKE) test ) || exit 1; done
+}
+win32 {
+    WIN_BINDIR=
+    debug_and_release {
+        WIN_BINDIR=release
+    }
+
+    RUNTEST=$${TOP_SOURCE_DIR}/unittests/runTest.bat
+    RUNTEST=$$replace(RUNTEST, /, \\)
+    LIB_PATH=$$TOP_BUILD_DIR/lib
+    LIB_PATH=$$replace(LIB_PATH, /, \\)
+    test.commands=for %d in ($${SUBDIRS}); do $$RUNTEST $$LIB_PATH "%d" $$WIN_BINDIR || exit 1; done
+}
+test.depends = first
+QMAKE_EXTRA_TARGETS += test

--- a/ufo-detector-engine/ufo-detector-engine.pri
+++ b/ufo-detector-engine/ufo-detector-engine.pri
@@ -24,7 +24,8 @@ SOURCES += $$PWD/recorder.cpp \
     $$PWD/videobuffer.cpp \
     $$PWD/videocodecsupportinfo.cpp \
     $$PWD/planechecker.cpp \
-    $$PWD/detectorstate.cpp
+    $$PWD/detectorstate.cpp \
+    $$PWD/datamanager.cpp
 
 HEADERS  += $$PWD/recorder.h \
     $$PWD/actualdetector.h \
@@ -38,4 +39,5 @@ HEADERS  += $$PWD/recorder.h \
     $$PWD/videobuffer.h \
     $$PWD/videocodecsupportinfo.h \
     $$PWD/planechecker.h \
-    $$PWD/detectorstate.h
+    $$PWD/detectorstate.h \
+    $$PWD/datamanager.h

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -43,7 +43,7 @@ bool Console::init() {
     connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(onPositiveMessage()));
     connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(onNegativeMessage()));
     connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(onDetectionAreaFileReadError()));
-    connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(onVideoSaved(QString,QString,QString)));
+    connect(m_dataManager, SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(onVideoSaved(QString,QString,QString)));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingStarted()), this, SLOT(onRecordingStarted()));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingFinished()), this, SLOT(onRecordingFinished()));
     connect(m_actualDetector, SIGNAL(progressValueChanged(int)), this, SLOT(onDetectorStartProgressChanged(int)));

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -1,0 +1,67 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "console.h"
+
+Console::Console(Config* config, ActualDetector* detector, QObject* parent) : QObject(parent) {
+    m_config = config;
+    m_actualDetector = detector;
+}
+
+void Console::setSignalsAndSlots() {
+    connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(onPositiveMessage()));
+    connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(onNegativeMessage()));
+    //connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(setErrorReadingDetectionAreaFile()));
+    //connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToVideoList(QString,QString,QString)));
+    connect(m_actualDetector->getRecorder(), SIGNAL(recordingStarted()), this, SLOT(onRecordingStarted()));
+    connect(m_actualDetector->getRecorder(), SIGNAL(recordingFinished()), this, SLOT(onRecordingFinished()));
+    connect(m_actualDetector, SIGNAL(progressValueChanged(int)), this, SLOT(onDetectorStartProgressChanged(int)));
+    connect(m_actualDetector, SIGNAL(broadcastOutputText(QString)), this, SLOT(logMessage(QString)));
+
+    if (m_config->checkAirplanes()) {
+        m_planeChecker = new PlaneChecker(this, m_config->coordinates());
+        connect(m_planeChecker, SIGNAL(foundNumberOfPlanes(int)), m_actualDetector, SLOT(setAmountOfPlanes(int)));
+        connect(m_actualDetector, SIGNAL(checkPlane()), m_planeChecker, SLOT(callApi()));
+    }
+}
+
+void Console::onRecordingStarted() {
+    std::cout << "Video recording started" << std::endl;
+}
+
+void Console::onRecordingFinished() {
+    std::cout << "Video recording finished" << std::endl;
+}
+
+void Console::onDetectorStartProgressChanged(int progress) {
+    if (100 == progress) {
+        std::cout << "Detector started" << std::endl;
+    }
+}
+
+void Console::logMessage(QString message) {
+    std::cout << message.toLocal8Bit().data() << std::endl;
+}
+
+void Console::onPositiveMessage() {
+    logMessage("Positive");
+}
+
+void Console::onNegativeMessage() {
+    logMessage("Negative");
+}

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -22,15 +22,15 @@ Console::Console(Config* config, ActualDetector* detector, QObject* parent) : QO
     m_config = config;
     m_actualDetector = detector;
 
-    logMessage("Noise filter pixel size: " + m_config->noiseFilterPixelSize());
-    logMessage("Motion threshold size: " + m_config->motionThreshold());
+    logMessage("Noise filter pixel size: " + QString::number(m_config->noiseFilterPixelSize()));
+    logMessage("Motion threshold size: " + QString::number(m_config->motionThreshold()));
 }
 
 void Console::setSignalsAndSlots() {
     connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(onPositiveMessage()));
     connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(onNegativeMessage()));
-    //connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(setErrorReadingDetectionAreaFile()));
-    //connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToVideoList(QString,QString,QString)));
+    connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(onDetectionAreaFileReadError()));
+    connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(onVideoSaved(QString,QString,QString)));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingStarted()), this, SLOT(onRecordingStarted()));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingFinished()), this, SLOT(onRecordingFinished()));
     connect(m_actualDetector, SIGNAL(progressValueChanged(int)), this, SLOT(onDetectorStartProgressChanged(int)));
@@ -44,21 +44,21 @@ void Console::setSignalsAndSlots() {
 }
 
 void Console::onRecordingStarted() {
-    std::cout << "Video recording started" << std::endl;
+    logMessage("Video recording started");
 }
 
 void Console::onRecordingFinished() {
-    std::cout << "Video recording finished" << std::endl;
+    logMessage("Video recording finished");
 }
 
 void Console::onDetectorStartProgressChanged(int progress) {
     if (100 == progress) {
-        std::cout << "Detector started" << std::endl;
+        logMessage("Detector started");
     }
 }
 
 void Console::logMessage(QString message) {
-    std::cout << message.toLocal8Bit().data() << std::endl;
+    std::cout << message.toStdString() << std::endl;
 }
 
 void Console::onPositiveMessage() {
@@ -67,4 +67,15 @@ void Console::onPositiveMessage() {
 
 void Console::onNegativeMessage() {
     logMessage("Negative");
+}
+
+void Console::onDetectionAreaFileReadError() {
+    logMessage("Error reading detection area file " + m_config->detectionAreaFile());
+}
+
+void Console::onVideoSaved(QString filename, QString dateTime, QString length) {
+    Q_UNUSED(filename);
+    Q_UNUSED(dateTime);
+    Q_UNUSED(length);
+    logMessage("Video saved");
 }

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -21,6 +21,9 @@
 Console::Console(Config* config, ActualDetector* detector, QObject* parent) : QObject(parent) {
     m_config = config;
     m_actualDetector = detector;
+
+    logMessage("Noise filter pixel size: " + m_config->noiseFilterPixelSize());
+    logMessage("Motion threshold size: " + m_config->motionThreshold());
 }
 
 void Console::setSignalsAndSlots() {

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -26,7 +26,7 @@ Console::Console(Config* config, ActualDetector* detector, QObject* parent) : QO
     logMessage("Motion threshold size: " + QString::number(m_config->motionThreshold()));
 }
 
-void Console::setSignalsAndSlots() {
+bool Console::init() {
     connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(onPositiveMessage()));
     connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(onNegativeMessage()));
     connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(onDetectionAreaFileReadError()));
@@ -41,6 +41,7 @@ void Console::setSignalsAndSlots() {
         connect(m_planeChecker, SIGNAL(foundNumberOfPlanes(int)), m_actualDetector, SLOT(setAmountOfPlanes(int)));
         connect(m_actualDetector, SIGNAL(checkPlane()), m_planeChecker, SLOT(callApi()));
     }
+    return true;
 }
 
 void Console::onRecordingStarted() {
@@ -62,11 +63,11 @@ void Console::logMessage(QString message) {
 }
 
 void Console::onPositiveMessage() {
-    logMessage("Positive");
+    //logMessage("Positive");
 }
 
 void Console::onNegativeMessage() {
-    logMessage("Negative");
+    //logMessage("Negative");
 }
 
 void Console::onDetectionAreaFileReadError() {

--- a/ui-cli/console.cpp
+++ b/ui-cli/console.cpp
@@ -80,3 +80,8 @@ void Console::onVideoSaved(QString filename, QString dateTime, QString length) {
     Q_UNUSED(length);
     logMessage("Video saved");
 }
+
+void Console::onApplicationAboutToQuit() {
+    logMessage("Console::onApplicationAboutToQuit()");
+    m_actualDetector->stopThread();
+}

--- a/ui-cli/console.h
+++ b/ui-cli/console.h
@@ -23,6 +23,8 @@
 #include "actualdetector.h"
 #include "recorder.h"
 #include "planechecker.h"
+#include "datamanager.h"
+#include "camera.h"
 #include <QObject>
 
 /**
@@ -32,13 +34,22 @@ class Console : public QObject
 {
     Q_OBJECT
 public:
-    explicit Console(Config* config, ActualDetector* detector, QObject *parent = 0);
+    explicit Console(Config* config, ActualDetector* detector, Camera* camera,
+                     DataManager* dataManager, QObject *parent = 0);
+
+    ~Console();
 
     /**
-     * @brief Initialize object
+     * @brief Initialize object.
      * @return true on success
      */
     bool init();
+
+    /**
+     * @brief Start detection.
+     * @return
+     */
+    bool start();
 
 #ifndef _UNIT_TEST_
 private:
@@ -46,6 +57,9 @@ private:
     Config* m_config;
     ActualDetector* m_actualDetector;
     PlaneChecker* m_planeChecker;
+    Camera* m_camera;
+    DataManager* m_dataManager;
+    bool m_initialized;
 
 signals:
 

--- a/ui-cli/console.h
+++ b/ui-cli/console.h
@@ -34,7 +34,11 @@ class Console : public QObject
 public:
     explicit Console(Config* config, ActualDetector* detector, QObject *parent = 0);
 
-    void setSignalsAndSlots();
+    /**
+     * @brief Initialize object
+     * @return true on success
+     */
+    bool init();
 
 #ifndef _UNIT_TEST_
 private:

--- a/ui-cli/console.h
+++ b/ui-cli/console.h
@@ -1,0 +1,57 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONSOLE_H
+#define CONSOLE_H
+
+#include "config.h"
+#include "actualdetector.h"
+#include "recorder.h"
+#include "planechecker.h"
+#include <QObject>
+
+/**
+ * @brief Text-based user interface for UFO Detector
+ */
+class Console : public QObject
+{
+    Q_OBJECT
+public:
+    explicit Console(Config* config, ActualDetector* detector, QObject *parent = 0);
+
+    void setSignalsAndSlots();
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+    Config* m_config;
+    ActualDetector* m_actualDetector;
+    PlaneChecker* m_planeChecker;
+
+signals:
+
+public slots:
+    void onRecordingStarted();
+    void onRecordingFinished();
+    void onDetectorStartProgressChanged(int progress);
+    void logMessage(QString message);
+    void onPositiveMessage();
+    void onNegativeMessage();
+};
+
+#endif // CONSOLE_H

--- a/ui-cli/console.h
+++ b/ui-cli/console.h
@@ -58,6 +58,7 @@ public slots:
     void onNegativeMessage();
     void onDetectionAreaFileReadError();
     void onVideoSaved(QString filename, QString dateTime, QString length);
+    void onApplicationAboutToQuit();
 };
 
 #endif // CONSOLE_H

--- a/ui-cli/console.h
+++ b/ui-cli/console.h
@@ -49,9 +49,11 @@ public slots:
     void onRecordingStarted();
     void onRecordingFinished();
     void onDetectorStartProgressChanged(int progress);
-    void logMessage(QString message);
+    void logMessage(QString message);   /// @todo move into Logger class (screen, file, forward)
     void onPositiveMessage();
     void onNegativeMessage();
+    void onDetectionAreaFileReadError();
+    void onVideoSaved(QString filename, QString dateTime, QString length);
 };
 
 #endif // CONSOLE_H

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -58,21 +58,16 @@ int main(int argc, char *argv[])
         }
 
         ActualDetector actualDetector(&camera, &config, &a);
-        Console console(&config, &actualDetector, &a);
+
+        Console console(&config, &actualDetector, &camera, &dataManager, &a);
         console.init();
         a.connect(&a, SIGNAL(aboutToQuit()), &console, SLOT(onApplicationAboutToQuit()));
 
-        if (!actualDetector.start()) {
-            std::cerr << "Error starting detector" << std::endl;
+        if (!console.start()) {
+            std::cerr << "Error starting Console" << std::endl;
             return -1;
         }
-
-        std::cout << "Running main loop" << std::endl;
         return a.exec();
-
-        std::cout << "Main loop exited" << std::endl;
-        actualDetector.stopThread();
-
     } catch (std::exception &e) {
         std::cout << e.what() << std::endl;
     }

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     parser.setApplicationDescription(QCoreApplication::translate("ufo-detector-cli",
         "UFO Detector command line application"));
 
-    QCommandLineOption resetDetectionAreaFileOption("reset-detfile",
+    QCommandLineOption resetDetectionAreaFileOption("reset-area-file",
         QCoreApplication::translate("ufo-detector-cli", "Reset detection area file."));
     parser.addOption(resetDetectionAreaFileOption);
 

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -1,0 +1,55 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "camera.h"
+#include "actualdetector.h"
+#include "console.h"
+#include <iostream>
+#include <QCoreApplication>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication a(argc, argv);
+
+    try {
+        Config config;
+        Camera camera(config.cameraIndex(), config.cameraWidth(), config.cameraHeight());
+        if (!camera.init()) {
+            std::cerr << "Couldn't initialize web camera, quitting" << std::endl;
+            return -1;
+        }
+        ActualDetector actualDetector(&camera, &config, NULL);
+        Console console(&config, &actualDetector);
+        console.setSignalsAndSlots();
+
+        if (!actualDetector.start()) {
+            std::cerr << "Error starting detector" << std::endl;
+            return -1;
+        }
+
+        std::cout << "Running main loop" << std::endl;
+        return a.exec();
+
+        actualDetector.stopThread();
+
+    } catch (std::exception &e) {
+        std::cout << e.what() << std::endl;
+    }
+    return -1;
+}

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
             std::cerr << "Problems in data manager initialization" << std::endl;
         }
 
-        ActualDetector actualDetector(&camera, &config, &a);
+        ActualDetector actualDetector(&camera, &config, &dataManager, &a);
 
         Console console(&config, &actualDetector, &camera, &dataManager, &a);
         console.init();

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 
         ActualDetector actualDetector(&camera, &config, NULL);
         Console console(&config, &actualDetector);
-        console.setSignalsAndSlots();
+        console.init();
 
         if (!actualDetector.start()) {
             std::cerr << "Error starting detector" << std::endl;

--- a/ui-cli/main.cpp
+++ b/ui-cli/main.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "camera.h"
 #include "actualdetector.h"
+#include "datamanager.h"
 #include "console.h"
 #include <iostream>
 #include <QCoreApplication>
@@ -34,6 +35,11 @@ int main(int argc, char *argv[])
             std::cerr << "Couldn't initialize web camera, quitting" << std::endl;
             return -1;
         }
+        DataManager dataManager(&config);
+        if (!dataManager.init()) {
+            std::cerr << "Problems in data manager initialization" << std::endl;
+        }
+
         ActualDetector actualDetector(&camera, &config, NULL);
         Console console(&config, &actualDetector);
         console.setSignalsAndSlots();
@@ -46,6 +52,7 @@ int main(int argc, char *argv[])
         std::cout << "Running main loop" << std::endl;
         return a.exec();
 
+        std::cout << "Main loop exited" << std::endl;
         actualDetector.stopThread();
 
     } catch (std::exception &e) {

--- a/ui-cli/ufo-detector-cli.pro
+++ b/ui-cli/ufo-detector-cli.pro
@@ -20,4 +20,3 @@ SOURCES += main.cpp \
 HEADERS += \
     console.h
 
-

--- a/ui-cli/ufo-detector-cli.pro
+++ b/ui-cli/ufo-detector-cli.pro
@@ -1,0 +1,23 @@
+QT += core
+QT -= gui
+
+unix {
+    QMAKE_CXXFLAGS += -std=c++1y
+    CONFIG += c++1y
+}
+
+TARGET = ufo-detector-cli
+CONFIG += console
+CONFIG -= app_bundle
+
+TEMPLATE = app
+
+include(../ufo-detector-engine/ufo-detector-engine.pri)
+
+SOURCES += main.cpp \
+    console.cpp
+
+HEADERS += \
+    console.h
+
+

--- a/ui-qt/Detector.pro
+++ b/ui-qt/Detector.pro
@@ -28,6 +28,8 @@ include(../ufo-detector-engine/ufo-detector-engine.pri)
 SOURCES += main.cpp\
     mainwindow.cpp \
     graphicsscene.cpp \
+    polygonnode.cpp \
+    polygonedge.cpp \
     videowidget.cpp \
     clickablelabel.cpp \
     imageexplorer.cpp \
@@ -41,6 +43,8 @@ SOURCES += main.cpp\
 HEADERS  += \
     mainwindow.h \
     graphicsscene.h \
+    polygonnode.h \
+    polygonedge.h \
     videowidget.h \
     clickablelabel.h \
     imageexplorer.h \

--- a/ui-qt/Detector.pro
+++ b/ui-qt/Detector.pro
@@ -36,8 +36,7 @@ SOURCES += main.cpp\
     cameraresolutiondialog.cpp \
     videolist.cpp \
     videouploaderdialog.cpp \
-    updateapplicationdialog.cpp \
-    ../ufo-detector-engine/datamanager.cpp
+    updateapplicationdialog.cpp
 
 HEADERS  += \
     mainwindow.h \
@@ -50,8 +49,7 @@ HEADERS  += \
     cameraresolutiondialog.h \
     videolist.h \
     videouploaderdialog.h \
-    updateapplicationdialog.h \
-    ../ufo-detector-engine/datamanager.h
+    updateapplicationdialog.h
 
 FORMS    += \
     mainwindow.ui \

--- a/ui-qt/Detector.pro
+++ b/ui-qt/Detector.pro
@@ -36,7 +36,8 @@ SOURCES += main.cpp\
     cameraresolutiondialog.cpp \
     videolist.cpp \
     videouploaderdialog.cpp \
-    updateapplicationdialog.cpp
+    updateapplicationdialog.cpp \
+    ../ufo-detector-engine/datamanager.cpp
 
 HEADERS  += \
     mainwindow.h \
@@ -49,7 +50,8 @@ HEADERS  += \
     cameraresolutiondialog.h \
     videolist.h \
     videouploaderdialog.h \
-    updateapplicationdialog.h
+    updateapplicationdialog.h \
+    ../ufo-detector-engine/datamanager.h
 
 FORMS    += \
     mainwindow.ui \

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -18,15 +18,6 @@
 
 #include "detectionareaeditdialog.h"
 #include "ui_detectionareaeditdialog.h"
-#include <opencv2/highgui/highgui.hpp>
-#include <QGraphicsSceneMouseEvent>
-#include <QPainter>
-#include <iostream>
-#include <QDir>
-#include <QtXml>
-
-using namespace cv;
-using namespace std;
 
 DetectionAreaEditDialog::DetectionAreaEditDialog(QWidget *parent, Camera *camPtr, Config *configPtr) :
     QDialog(parent),  ui(new Ui::DetectionAreaEditDialog), m_camera(camPtr), m_config(configPtr)
@@ -86,7 +77,9 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     stream.writeEndDocument();
 
     file.close();
+    delete polygon;
     ui->labelInfo->setText(tr("Saved %1").arg(file.fileName()));
+
     return true;
 }
 

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -131,7 +131,7 @@ void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
     ui->image->setScene(scene);
     ui->image->show();
     isPictureTaken=true;
-    ui->labelInfo->setText(tr("2. Click to create points around the area of the dection. Connect the first and last points using the \"Connect\" button."));
+    ui->labelInfo->setText(tr("2. Click to create points around the area of the detection. Connect the first and last points using the \"Connect\" button."));
     ui->buttonClear->setEnabled(true);
     ui->buttonConnect->setEnabled(true);
 }

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -36,7 +36,6 @@ DetectionAreaEditDialog::DetectionAreaEditDialog(QWidget* parent, Camera* camera
     m_scene = new GraphicsScene(this, m_camera);
     ui->image->setScene(m_scene);
     ui->image->show();
-    //ui->image->setMouseTracking(true);
     m_pictureTaken = false;
     m_isFirstPicture = true;
     ui->buttonClear->setEnabled(false);

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -43,6 +43,7 @@ DetectionAreaEditDialog::DetectionAreaEditDialog(QWidget *parent, Camera *camPtr
     m_scene = new GraphicsScene(this, m_camera);
     ui->image->setScene(m_scene);
     ui->image->show();
+    //ui->image->setMouseTracking(true);
     m_pictureTaken = false;
     ui->buttonClear->setEnabled(false);
     ui->buttonConnect->setEnabled(false);

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -112,14 +112,19 @@ bool DetectionAreaEditDialog::checkPolygon(QPolygon* polygon) {
 
 void DetectionAreaEditDialog::on_buttonConnect_clicked()
 {
-    m_scene->connectDots();
-    ui->labelInfo->setText(tr("3. Press the \"Save\" button to save your detection area file"));
+    if (m_scene->connectDots()) {
+        ui->buttonSave->setEnabled(true);
+        ui->labelInfo->setText(tr("3. Press the \"Save\" button to save your detection area file"));
+    } else {
+        ui->labelInfo->setText(tr("ERROR not enough points. Draw at least three points around your area of detection."));
+    }
 }
 
 void DetectionAreaEditDialog::on_buttonClear_clicked()
 {
     m_scene->clearPoly();
     m_scene->clear();
+    ui->buttonSave->setEnabled(false);
     ui->labelInfo->setText(tr("1. Take a picture with the webcam"));
 }
 
@@ -138,8 +143,6 @@ void DetectionAreaEditDialog::on_buttonSave_clicked() {
         QPolygon* polygon = m_scene->detectionAreaPolygon();
         if (checkPolygon(polygon)) {
             savePolygonsAsXml();
-        } else {
-            ui->labelInfo->setText(tr("ERROR not enough points. Draw at least three points around your area of detection."));
         }
     }
 }

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -111,7 +111,7 @@ bool DetectionAreaEditDialog::readPolygonsFromFile() {
     if (!m_dataManager) {
         return false;
     }
-    ok = m_dataManager->readDetectionAreaFile();
+    ok = m_dataManager->readDetectionAreaFile(false);
     if (!ok) {
         return false;
     }

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -130,6 +130,8 @@ void DetectionAreaEditDialog::on_buttonClear_clicked()
 
 void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
 {
+    m_scene->clearPoly();
+    m_scene->clear();
     m_scene->takePicture();
     m_pictureTaken = true;
     ui->labelInfo->setText(tr("2. Click to create points around the area of the detection. Connect the first and last points using the \"Connect\" button."));

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -38,13 +38,15 @@ DetectionAreaEditDialog::DetectionAreaEditDialog(QWidget *parent, Camera *camPtr
     {
          ui->labelInfo->setText(tr("Could not find area file: %1 - Check area file path in settings").arg(m_config->detectionAreaFile()));
          ui->buttonTakePicture->setEnabled(false);
-         ui->buttonConnect->setEnabled(false);
-         ui->buttonSave->setEnabled(false);
     }
 
-    m_pictureTaken=false;
+    m_scene = new GraphicsScene(this, m_camera);
+    ui->image->setScene(m_scene);
+    ui->image->show();
+    m_pictureTaken = false;
     ui->buttonClear->setEnabled(false);
     ui->buttonConnect->setEnabled(false);
+    ui->buttonSave->setEnabled(false);
 }
 
 bool DetectionAreaEditDialog::savePolygonsAsXml() {
@@ -123,10 +125,8 @@ void DetectionAreaEditDialog::on_buttonClear_clicked()
 
 void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
 {
-    m_scene = new GraphicsScene(this,m_camera);
-    ui->image->setScene(m_scene);
-    ui->image->show();
-    m_pictureTaken=true;
+    m_scene->takePicture();
+    m_pictureTaken = true;
     ui->labelInfo->setText(tr("2. Click to create points around the area of the detection. Connect the first and last points using the \"Connect\" button."));
     ui->buttonClear->setEnabled(true);
     ui->buttonConnect->setEnabled(true);

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -128,18 +128,9 @@ void DetectionAreaEditDialog::on_buttonSave_clicked() {
         if (scene->detectionAreaPolygon()->size() > 2) {
             /// @todo check area of polygon >= 1
             savePolygonsAsXml();
-            wasSaved = true;
         }
         else ui->labelInfo->setText(tr("ERROR not enough points. Draw at least three points around your area of detection."));
     }
-}
-
-void DetectionAreaEditDialog::closeEvent(QCloseEvent *)
-{
-//    if(wasSaved)
-//	  {
-//        emit savedFile();
-//    }
 }
 
 DetectionAreaEditDialog::~DetectionAreaEditDialog()

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -158,6 +158,7 @@ void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
         ui->labelInfo->setText(tr("2. Click to create points around the area of the detection. Connect the first and last points using the \"Connect\" button."));
         ui->buttonClear->setEnabled(true);
         ui->buttonConnect->setEnabled(true);
+        ui->buttonSave->setEnabled(false);
     }
 }
 

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -77,7 +77,6 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     stream.writeEndDocument();
 
     file.close();
-    delete polygon;
     ui->labelInfo->setText(tr("Saved %1").arg(file.fileName()));
 
     return true;

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -94,6 +94,27 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     return true;
 }
 
+bool DetectionAreaEditDialog::checkPolygon(QPolygon* polygon) {
+    if (!polygon) {
+        return false;
+    }
+
+    if (polygon->size() <= 2) {
+        return false;
+    }
+
+    QRect boundingRect = polygon->boundingRect();
+
+    for (int bx = boundingRect.x(); bx < boundingRect.width(); bx++) {
+        for (int by = boundingRect.y(); by < boundingRect.height(); by++) {
+            if (polygon->containsPoint(QPoint(bx, by), Qt::OddEvenFill)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void DetectionAreaEditDialog::on_buttonConnect_clicked()
 {
     scene->connectDots();
@@ -125,11 +146,12 @@ void DetectionAreaEditDialog::on_buttonSave_clicked() {
     {
         ui->progressBar->show();
         ui->progressBar->repaint();
-        if (scene->detectionAreaPolygon()->size() > 2) {
-            /// @todo check area of polygon >= 1
+        QPolygon* polygon = scene->detectionAreaPolygon();
+        if (checkPolygon(polygon)) {
             savePolygonsAsXml();
+        } else {
+            ui->labelInfo->setText(tr("ERROR not enough points. Draw at least three points around your area of detection."));
         }
-        else ui->labelInfo->setText(tr("ERROR not enough points. Draw at least three points around your area of detection."));
     }
 }
 

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -49,7 +49,6 @@ DetectionAreaEditDialog::DetectionAreaEditDialog(QWidget *parent, Camera *camPtr
     isPictureTaken=false;
     ui->buttonClear->setEnabled(false);
     ui->buttonConnect->setEnabled(false);
-    ui->progressBar->hide();
 }
 
 bool DetectionAreaEditDialog::savePolygonsAsXml() {
@@ -86,8 +85,6 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     stream.writeEndElement(); // detectionarea
     stream.writeEndElement(); // detectionarealist
     stream.writeEndDocument();
-
-    ui->progressBar->setValue(100);
 
     file.close();
     ui->labelInfo->setText("Saved " + file.fileName());
@@ -130,8 +127,6 @@ void DetectionAreaEditDialog::on_buttonClear_clicked()
 
 void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
 {
-    ui->progressBar->setValue(0);
-    ui->progressBar->hide();
     scene = new GraphicsScene(this,cameraPtr);
     ui->image->setScene(scene);
     ui->image->show();
@@ -144,8 +139,6 @@ void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
 void DetectionAreaEditDialog::on_buttonSave_clicked() {
     if (isPictureTaken)
     {
-        ui->progressBar->show();
-        ui->progressBar->repaint();
         QPolygon* polygon = scene->detectionAreaPolygon();
         if (checkPolygon(polygon)) {
             savePolygonsAsXml();

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -52,7 +52,7 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     QPolygon* polygon = m_scene->detectionAreaPolygon();
 
     if(!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        ui->labelInfo->setText("ERROR saving " + file.fileName());
+        ui->labelInfo->setText(tr("ERROR saving %1").arg(file.fileName()));
         return false;
     }
 
@@ -83,7 +83,7 @@ bool DetectionAreaEditDialog::savePolygonsAsXml() {
     stream.writeEndDocument();
 
     file.close();
-    ui->labelInfo->setText("Saved " + file.fileName());
+    ui->labelInfo->setText(tr("Saved %1").arg(file.fileName()));
     return true;
 }
 

--- a/ui-qt/detectionareaeditdialog.cpp
+++ b/ui-qt/detectionareaeditdialog.cpp
@@ -115,7 +115,7 @@ void DetectionAreaEditDialog::on_buttonConnect_clicked()
 
 void DetectionAreaEditDialog::on_buttonClear_clicked()
 {
-    m_scene->clearPoly();
+    m_scene->clearPolygon();
     m_scene->clear();
     ui->buttonSave->setEnabled(false);
     ui->labelInfo->setText(tr("1. Take a picture with the webcam"));
@@ -123,7 +123,7 @@ void DetectionAreaEditDialog::on_buttonClear_clicked()
 
 void DetectionAreaEditDialog::on_buttonTakePicture_clicked()
 {
-    m_scene->clearPoly();
+    m_scene->clearPolygon();
     m_scene->clear();
     m_scene->takePicture();
     m_pictureTaken = true;

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -20,9 +20,9 @@
 #define DIALOG_H
 
 #include "config.h"
+#include "graphicsscene.h"
 #include <QDialog>
 #include <opencv2/opencv.hpp>
-#include "graphicsscene.h"
 #include <chrono>
 #include <QApplication>
 
@@ -67,12 +67,6 @@ private:
     int HEIGHT;
     std::string areaFilePath;
     bool isPictureTaken;
-    bool wasSaved;
-    void closeEvent(QCloseEvent *);
-
-signals:
-    //void savedFile();
-
 };
 
 #endif // DIALOG_H

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -63,6 +63,13 @@ private:
      */
     bool savePolygonsAsXml();
 
+    /**
+     * @brief Check that polygon is acceptable as detection area polygon: area is larger than 1.
+     * @param polygon
+     * @return true if polygon is valid, false if not
+     */
+    bool checkPolygon(QPolygon* polygon);
+
     int WIDTH;
     int HEIGHT;
     std::string areaFilePath;

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -48,7 +48,6 @@ public:
 private slots:
     void on_buttonTakePicture_clicked();
     void on_buttonSave_clicked();
-    void on_savePolygonFilePushButton_clicked();
     void on_buttonConnect_clicked();
     void on_buttonClear_clicked();
 
@@ -59,15 +58,9 @@ private:
     GraphicsScene *scene;
 
     /**
-     * @brief Get all points inside the selected area and pass vector with points to savePointsAsXML()
+     * @brief Save detection area polygons into XML file.
+     * @return true on success, false on failure
      */
-    void getPointsInContour(std::vector<cv::Point2f> & contour);
-
-    /**
-     * @brief Save the points to area xml
-     */
-    void savePointsAsXML(std::vector<cv::Point2f> & contour);
-
     bool savePolygonsAsXml();
 
     int WIDTH;

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "graphicsscene.h"
+#include "datamanager.h"
 #include <QDialog>
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
@@ -51,7 +52,8 @@ class DetectionAreaEditDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit DetectionAreaEditDialog(QWidget *parent = 0, Camera *camPtr = 0, Config *configPtr = 0);
+    explicit DetectionAreaEditDialog(QWidget *parent = 0, Camera* camera = 0,
+        Config* config = 0, DataManager* dataManager = 0);
     ~DetectionAreaEditDialog();
 
 private slots:
@@ -64,8 +66,10 @@ private:
     Ui::DetectionAreaEditDialog *ui;
     Camera *m_camera;
     Config *m_config;
+    DataManager* m_dataManager;
     GraphicsScene *m_scene;
     bool m_pictureTaken;
+    bool m_isFirstPicture;
 
     /**
      * @brief Save detection area polygons into XML file.
@@ -79,6 +83,12 @@ private:
      * @return true if polygon is valid, false if not
      */
     bool checkPolygon(QPolygon* polygon);
+
+    /**
+     * @brief Read existing detection area polygons from file.
+     * @return true on success, false on failure
+     */
+    bool readPolygonsFromFile();
 };
 
 #endif // DIALOG_H

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -22,9 +22,18 @@
 #include "config.h"
 #include "graphicsscene.h"
 #include <QDialog>
-#include <opencv2/opencv.hpp>
-#include <chrono>
 #include <QApplication>
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <QDir>
+#include <QtXml>
+#include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <chrono>
+#include <iostream>
+
+using namespace cv;
+using namespace std;
 
 class Camera;
 

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -53,9 +53,10 @@ private slots:
 
 private:
     Ui::DetectionAreaEditDialog *ui;
-    Camera *cameraPtr;
+    Camera *m_camera;
     Config *m_config;
-    GraphicsScene *scene;
+    GraphicsScene *m_scene;
+    bool m_pictureTaken;
 
     /**
      * @brief Save detection area polygons into XML file.
@@ -69,11 +70,6 @@ private:
      * @return true if polygon is valid, false if not
      */
     bool checkPolygon(QPolygon* polygon);
-
-    int WIDTH;
-    int HEIGHT;
-    std::string areaFilePath;
-    bool isPictureTaken;
 };
 
 #endif // DIALOG_H

--- a/ui-qt/detectionareaeditdialog.h
+++ b/ui-qt/detectionareaeditdialog.h
@@ -23,6 +23,8 @@
 #include <QDialog>
 #include <opencv2/opencv.hpp>
 #include "graphicsscene.h"
+#include <chrono>
+#include <QApplication>
 
 class Camera;
 
@@ -46,6 +48,7 @@ public:
 private slots:
     void on_buttonTakePicture_clicked();
     void on_buttonSave_clicked();
+    void on_savePolygonFilePushButton_clicked();
     void on_buttonConnect_clicked();
     void on_buttonClear_clicked();
 
@@ -64,13 +67,15 @@ private:
      * @brief Save the points to area xml
      */
     void savePointsAsXML(std::vector<cv::Point2f> & contour);
+
+    bool savePolygonsAsXml();
+
     int WIDTH;
     int HEIGHT;
     std::string areaFilePath;
     bool isPictureTaken;
     bool wasSaved;
     void closeEvent(QCloseEvent *);
-
 
 signals:
     //void savedFile();

--- a/ui-qt/detectionareaeditdialog.ui
+++ b/ui-qt/detectionareaeditdialog.ui
@@ -81,13 +81,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QProgressBar" name="progressBar">
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="buttonSave">
        <property name="text">
         <string>Save to file</string>

--- a/ui-qt/detectionareaeditdialog.ui
+++ b/ui-qt/detectionareaeditdialog.ui
@@ -90,7 +90,14 @@
      <item>
       <widget class="QPushButton" name="buttonSave">
        <property name="text">
-        <string>Save to file</string>
+        <string>Save point file</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="savePolygonFilePushButton">
+       <property name="text">
+        <string>Save polygon file</string>
        </property>
       </widget>
      </item>

--- a/ui-qt/detectionareaeditdialog.ui
+++ b/ui-qt/detectionareaeditdialog.ui
@@ -90,14 +90,7 @@
      <item>
       <widget class="QPushButton" name="buttonSave">
        <property name="text">
-        <string>Save point file</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="savePolygonFilePushButton">
-       <property name="text">
-        <string>Save polygon file</string>
+        <string>Save to file</string>
        </property>
       </widget>
      </item>

--- a/ui-qt/detector.qss
+++ b/ui-qt/detector.qss
@@ -27,7 +27,7 @@ QMainWindow, QDialog {
     color: white;
 }
 
-QPushButton, QToolButton, QLineEdit, QComboBox, QTextEdit, QListView, QTreeView {
+QPushButton, QToolButton, QComboBox, QListView, QTreeView {
     background-color: #3c4a62;
     color: white;
 }
@@ -35,6 +35,12 @@ QPushButton, QToolButton, QLineEdit, QComboBox, QTextEdit, QListView, QTreeView 
 QLineEdit:disabled, QPushButton:disabled, QToolButton:disabled {
     background-color: #515c65;
     color: grey;
+}
+
+QLineEdit, QTextEdit {
+    background-color: #3c4a62;
+    color: white;
+    border: 1px solid #777777;
 }
 
 QLabel, QCheckBox, QScrollBar {

--- a/ui-qt/detector.qss
+++ b/ui-qt/detector.qss
@@ -32,6 +32,11 @@ QPushButton, QToolButton, QLineEdit, QComboBox, QTextEdit, QListView, QTreeView 
     color: white;
 }
 
+QLineEdit:disabled, QPushButton:disabled, QToolButton:disabled {
+    background-color: #515c65;
+    color: grey;
+}
+
 QLabel, QCheckBox, QScrollBar {
     background-color: #515c65;
     color: white;
@@ -63,11 +68,5 @@ QComboBox QListView {
 VideoWidget ClickableLabel, VideoWidget QLabel {
     background-color: #3c4a62;
     border: 1px solid #777777;
-}
-
-QLineEdit:disabled
-{
-    background-color: #515c65;
-    color: grey;
 }
 

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -142,8 +142,9 @@ bool GraphicsScene::connectDots()
     return false;
 }
 
-void GraphicsScene::clearPoly()
+void GraphicsScene::clearPolygon()
 {
+    m_polygon.clear();
     m_polygonClosed = false;
 
     while (!m_polygonNodes.isEmpty()) {
@@ -170,7 +171,7 @@ bool GraphicsScene::takePicture() {
 
 GraphicsScene::~GraphicsScene()
 {
-    clearPoly();
+    clearPolygon();
     qDebug() << "deleted scene";
 }
 

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -23,7 +23,6 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <iostream>
 #include <QPainter>
-#include "camera.h"
 
 using namespace cv;
 using namespace std;
@@ -31,14 +30,11 @@ using namespace std;
 /*
  * Graphics scene for drawing points to the detection area dialog
  */
-GraphicsScene::GraphicsScene(QObject *parent, Camera *camPtr) :
+GraphicsScene::GraphicsScene(QObject *parent, Camera *camera) :
     QGraphicsScene(parent)
 {
-    Mat src;    
-    src = camPtr->getWebcamFrame();
-    cv::cvtColor(src, src, CV_BGR2RGB);
-    QImage imgToDisplay = QImage((uchar*)src.data, src.cols, src.rows, src.step, QImage::Format_RGB888);
-    addPixmap(QPixmap::fromImage(imgToDisplay));
+    m_camera = camera;
+    m_picture = NULL;
 }
 
 void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
@@ -96,9 +92,22 @@ void GraphicsScene::connectDots()
     }
 
 }
+
 void GraphicsScene::clearPoly()
 {
     pol.clear();
+}
+
+bool GraphicsScene::takePicture() {
+    Mat src;
+    src = m_camera->getWebcamFrame();
+    cv::cvtColor(src, src, CV_BGR2RGB);
+    QImage imgToDisplay = QImage((uchar*)src.data, src.cols, src.rows, src.step, QImage::Format_RGB888);
+    if (items().contains((QGraphicsItem*)m_picture)) {
+        removeItem((QGraphicsItem*)m_picture);
+    }
+    m_picture = addPixmap(QPixmap::fromImage(imgToDisplay));
+    return true;
 }
 
 GraphicsScene::~GraphicsScene()

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -50,6 +50,7 @@ void GraphicsScene::addDetectionAreaPolygon(QPolygon* polygon) {
             m_polygonEdges.append(edge);
         } else {
             this->addItem(newNode);
+            newNode->setZValue(100);
             m_polygonNodes.append(newNode);
         }
     }
@@ -194,6 +195,5 @@ bool GraphicsScene::takePicture() {
 GraphicsScene::~GraphicsScene()
 {
     clearPolygon();
-    qDebug() << "deleted scene";
 }
 

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -33,6 +33,28 @@ GraphicsScene::GraphicsScene(QObject *parent, Camera *camera) :
     m_tmpLine = NULL;
 }
 
+void GraphicsScene::addDetectionAreaPolygon(QPolygon* polygon) {
+    if (!polygon) {
+        return;
+    }
+    for (int i = 0; i < polygon->size(); i++) {
+        PolygonNode* newNode = new PolygonNode();
+        newNode->setPos(polygon->at(i));
+        if (i > 0) {
+            PolygonNode* prevNode = m_polygonNodes.last();
+            PolygonEdge* edge = new PolygonEdge(prevNode, newNode);
+            this->addItem(newNode);
+            newNode->setZValue(100);
+            m_polygonNodes.append(newNode);
+            this->addItem(edge);
+            m_polygonEdges.append(edge);
+        } else {
+            this->addItem(newNode);
+            m_polygonNodes.append(newNode);
+        }
+    }
+}
+
 void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (mouseEvent->button() != Qt::LeftButton) {
@@ -57,7 +79,7 @@ void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
     m_tmpNode = new PolygonNode();
     this->addItem(m_tmpNode);
     m_tmpNode->setPos(pos);
-    m_tmpNode->setZValue(10);
+    m_tmpNode->setZValue(100);
     m_tmpNode->grabMouse();
     m_addingNode = true;
 
@@ -130,7 +152,7 @@ QPolygon* GraphicsScene::detectionAreaPolygon() {
 
 bool GraphicsScene::connectDots()
 {
-    if (m_polygonNodes.size() > 2) {
+    if ((m_polygonNodes.size() > 2) && !m_polygonClosed) {
         PolygonNode* firstNode = m_polygonNodes.first();
         PolygonNode* lastNode = m_polygonNodes.last();
         PolygonEdge* edge = new PolygonEdge(lastNode, firstNode);

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -82,7 +82,10 @@ std::vector<Point2f> GraphicsScene::getCoor()
          cout << "empty vector" << endl;
          return vecPoint;
     }
+}
 
+QPolygon* GraphicsScene::detectionAreaPolygon() {
+    return &pol;
 }
 
 void GraphicsScene::connectDots()

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -121,11 +121,11 @@ void GraphicsScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 }
 
 QPolygon* GraphicsScene::detectionAreaPolygon() {
-    QPolygon* ret = new QPolygon();
+    m_polygon.clear();
     for (int i = 0; i < m_polygonNodes.count(); i++) {
-        ret->append(m_polygonNodes.at(i)->pos().toPoint());
+        m_polygon << m_polygonNodes.at(i)->pos().toPoint();
     }
-    return ret;
+    return &m_polygon;
 }
 
 bool GraphicsScene::connectDots()

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -35,12 +35,16 @@ GraphicsScene::GraphicsScene(QObject *parent, Camera *camera) :
 {
     m_camera = camera;
     m_picture = NULL;
+    m_polygonClosed = false;
 }
 
 void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (mouseEvent->button() == Qt::LeftButton)
 	{
+        if (m_polygonClosed) {
+            return;
+        }
         QPoint pos = mouseEvent->scenePos().toPoint();
         pol.append(pos);
         double rad  = 2;
@@ -62,8 +66,9 @@ bool GraphicsScene::connectDots()
 {
     if (pol.size()>2)
 	{
-       addLine(QLine(pol.first(),pol.last()),QPen(Qt::red,1));
-       return true;
+        addLine(QLine(pol.first(),pol.last()),QPen(Qt::red,1));
+        m_polygonClosed = true;
+        return true;
     }
     return false;
 }
@@ -71,6 +76,7 @@ bool GraphicsScene::connectDots()
 void GraphicsScene::clearPoly()
 {
     pol.clear();
+    m_polygonClosed = false;
 }
 
 bool GraphicsScene::takePicture() {

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -54,32 +54,6 @@ void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
     }
 }
 
-std::vector<Point2f> GraphicsScene::getCoor()
-{
-    std::vector<Point2f> vecPoint;
-
-    if (pol.size()>2)
-	{
-        connectDots();
-        std::vector<QPoint> myVec = pol.toStdVector();
-
-        for(int i=0; i < (int)myVec.size(); i++)
-		{
-            QPoint point = myVec[i];
-            Point2f p(point.x(), point.y());
-           vecPoint.push_back(p);
-        }
-
-        pol.clear();
-        return vecPoint;
-    }
-    else
-	{
-         cout << "empty vector" << endl;
-         return vecPoint;
-    }
-}
-
 QPolygon* GraphicsScene::detectionAreaPolygon() {
     return &pol;
 }

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -43,16 +43,12 @@ void GraphicsScene::addDetectionAreaPolygon(QPolygon* polygon) {
         if (i > 0) {
             PolygonNode* prevNode = m_polygonNodes.last();
             PolygonEdge* edge = new PolygonEdge(prevNode, newNode);
-            this->addItem(newNode);
-            newNode->setZValue(100);
-            m_polygonNodes.append(newNode);
             this->addItem(edge);
             m_polygonEdges.append(edge);
-        } else {
-            this->addItem(newNode);
-            newNode->setZValue(100);
-            m_polygonNodes.append(newNode);
         }
+        this->addItem(newNode);
+        newNode->setZValue(100);
+        m_polygonNodes.append(newNode);
     }
 }
 

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -41,7 +41,7 @@ GraphicsScene::GraphicsScene(QObject *parent, Camera *camera) :
 void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (mouseEvent->button() == Qt::LeftButton)
-	{
+    {
         if (m_polygonClosed) {
             return;
         }
@@ -50,7 +50,7 @@ void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
         double rad  = 2;
         this->addEllipse(pos.x()-rad, pos.y()-rad, rad*2.0, rad*2.0, QPen(Qt::red), QBrush(Qt::SolidPattern));
         if(pol.size() > 1)
-		{
+        {
             QPainterPath myPath;
             myPath.addPolygon(pol);
             addPath(myPath,QPen(Qt::red,1));
@@ -65,7 +65,7 @@ QPolygon* GraphicsScene::detectionAreaPolygon() {
 bool GraphicsScene::connectDots()
 {
     if (pol.size()>2)
-	{
+    {
         addLine(QLine(pol.first(),pol.last()),QPen(Qt::red,1));
         m_polygonClosed = true;
         return true;

--- a/ui-qt/graphicsscene.cpp
+++ b/ui-qt/graphicsscene.cpp
@@ -58,13 +58,14 @@ QPolygon* GraphicsScene::detectionAreaPolygon() {
     return &pol;
 }
 
-void GraphicsScene::connectDots()
+bool GraphicsScene::connectDots()
 {
     if (pol.size()>2)
 	{
        addLine(QLine(pol.first(),pol.last()),QPen(Qt::red,1));
+       return true;
     }
-
+    return false;
 }
 
 void GraphicsScene::clearPoly()

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -47,6 +47,12 @@ public:
     ~GraphicsScene();
 
     /**
+     * @brief Add a detection area polygon into scene.
+     * @param polygon
+     */
+    void addDetectionAreaPolygon(QPolygon* polygon);
+
+    /**
      * @brief Get detection area polygon.
      * @return
      *

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -22,6 +22,7 @@
 #include <QGraphicsScene>
 #include <QPoint>
 #include <QMouseEvent>
+#include <QList>
 #include <opencv2/imgproc/imgproc.hpp>
 
 class Camera;
@@ -36,6 +37,15 @@ public:
     explicit GraphicsScene(QObject *parent = 0, Camera* camPtr =0);
     ~GraphicsScene();
     std::vector<cv::Point2f> getCoor();
+
+    /**
+     * @brief Get detection area polygon.
+     * @return
+     *
+     * @todo enable using multiple polygons
+     */
+    QPolygon* detectionAreaPolygon();
+
     void connectDots();
     void clearPoly();
 

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -20,6 +20,8 @@
 #define GRAPHICSSCENE_H
 
 #include "camera.h"
+#include "polygonnode.h"
+#include "polygonedge.h"
 #include <QGraphicsScene>
 #include <QPoint>
 #include <QMouseEvent>
@@ -32,6 +34,7 @@
 #include <iostream>
 #include <QPainter>
 #include <QGraphicsItem>
+#include <QVector>
 
 /**
  * @brief Graphics scene for DetectionAreaEditDialog
@@ -68,25 +71,19 @@ public:
 #ifndef _UNIT_TEST_
 private:
 #endif
-    QPolygon pol;
+    QVector<PolygonNode*> m_polygonNodes;
+    QVector<PolygonEdge*> m_polygonEdges;
+    PolygonNode* m_tmpNode;     ///< new node, not yet added to polygon
     Camera* m_camera;
-    QGraphicsPixmapItem* m_picture;
-    QGraphicsPathItem* m_path;
+    QGraphicsPixmapItem* m_picture; ///< picture taken with webcam
     QGraphicsLineItem* m_tmpLine;   ///< line drawn when moving a newly added node
     bool m_polygonClosed;
-    bool m_addingNode;  ///< node is being added to polygon
-
-signals:
+    bool m_addingNode;  ///< whether dragged node is being added to polygon
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent);
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-
-public slots:
-    private:
-
-
 };
 
 #endif // GRAPHICSSCENE_H

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -35,7 +35,6 @@ class GraphicsScene : public QGraphicsScene
 public:
     explicit GraphicsScene(QObject *parent = 0, Camera* camera =0);
     ~GraphicsScene();
-    std::vector<cv::Point2f> getCoor();
 
     /**
      * @brief Get detection area polygon.

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -60,7 +60,7 @@ public:
      */
     bool connectDots();
 
-    void clearPoly();
+    void clearPolygon();
 
     /**
      * @brief Take picture with web camera and show it.

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -64,6 +64,7 @@ private:
     QPolygon pol;
     Camera* m_camera;
     QGraphicsPixmapItem* m_picture;
+    bool m_polygonClosed;
 
 signals:
 

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -71,6 +71,7 @@ public:
 #ifndef _UNIT_TEST_
 private:
 #endif
+    QPolygon m_polygon; ///< detection area polygon, updated in detectionAreaPolygon()
     QVector<PolygonNode*> m_polygonNodes;
     QVector<PolygonEdge*> m_polygonEdges;
     PolygonNode* m_tmpNode;     ///< new node, not yet added to polygon

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -44,7 +44,12 @@ public:
      */
     QPolygon* detectionAreaPolygon();
 
-    void connectDots();
+    /**
+     * @brief Close polygon by connecting start and end vertices.
+     * @return true if connecting was successful, false if not
+     */
+    bool connectDots();
+
     void clearPoly();
 
     /**

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -25,6 +25,13 @@
 #include <QMouseEvent>
 #include <QList>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <QDebug>
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <opencv2/highgui/highgui.hpp>
+#include <iostream>
+#include <QPainter>
+#include <QGraphicsItem>
 
 /**
  * @brief Graphics scene for DetectionAreaEditDialog
@@ -64,12 +71,17 @@ private:
     QPolygon pol;
     Camera* m_camera;
     QGraphicsPixmapItem* m_picture;
+    QGraphicsPathItem* m_path;
+    QGraphicsLineItem* m_tmpLine;   ///< line drawn when moving a newly added node
     bool m_polygonClosed;
+    bool m_addingNode;  ///< node is being added to polygon
 
 signals:
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
 
 public slots:
     private:

--- a/ui-qt/graphicsscene.h
+++ b/ui-qt/graphicsscene.h
@@ -19,13 +19,12 @@
 #ifndef GRAPHICSSCENE_H
 #define GRAPHICSSCENE_H
 
+#include "camera.h"
 #include <QGraphicsScene>
 #include <QPoint>
 #include <QMouseEvent>
 #include <QList>
 #include <opencv2/imgproc/imgproc.hpp>
-
-class Camera;
 
 /**
  * @brief Graphics scene for DetectionAreaEditDialog
@@ -34,7 +33,7 @@ class GraphicsScene : public QGraphicsScene
 {
     Q_OBJECT
 public:
-    explicit GraphicsScene(QObject *parent = 0, Camera* camPtr =0);
+    explicit GraphicsScene(QObject *parent = 0, Camera* camera =0);
     ~GraphicsScene();
     std::vector<cv::Point2f> getCoor();
 
@@ -49,8 +48,18 @@ public:
     void connectDots();
     void clearPoly();
 
+    /**
+     * @brief Take picture with web camera and show it.
+     * @return true on success, false on failure (webcam error)
+     */
+    bool takePicture();
+
+#ifndef _UNIT_TEST_
 private:
+#endif
     QPolygon pol;
+    Camera* m_camera;
+    QGraphicsPixmapItem* m_picture;
 
 signals:
 

--- a/ui-qt/main.cpp
+++ b/ui-qt/main.cpp
@@ -41,10 +41,15 @@ int main(int argc, char *argv[])
         }
 
         Config myConfig;
+        DataManager dataManager(&myConfig);
+        dataManager.init();
+
         Camera myCam(myConfig.cameraIndex(), myConfig.cameraWidth(), myConfig.cameraHeight());
         myCam.init();
-        MainWindow mainWindow(0, &myCam, &myConfig);
+
+        MainWindow mainWindow(&myCam, &myConfig, &dataManager, NULL);
         ActualDetector detector(&myCam, &myConfig, &mainWindow);
+
         mainWindow.setSignalsAndSlots(&detector);
         mainWindow.show();
 

--- a/ui-qt/main.cpp
+++ b/ui-qt/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         myCam.init();
 
         MainWindow mainWindow(&myCam, &myConfig, &dataManager, NULL);
-        ActualDetector detector(&myCam, &myConfig, &mainWindow);
+        ActualDetector detector(&myCam, &myConfig, &dataManager, &mainWindow);
 
         mainWindow.setSignalsAndSlots(&detector);
         mainWindow.show();

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -162,10 +162,10 @@ void MainWindow::setSignalsAndSlots(ActualDetector* actualDetector)
     connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(setPositiveMessage()));
     connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(setNegativeMessage()));
     connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(setErrorReadingDetectionAreaFile()));
-    connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToList(QString,QString,QString)));
+    connect(m_dataManager, SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToList(QString,QString,QString)));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingStarted()), this, SLOT(onRecordingStarted()));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingFinished()), this, SLOT(onRecordingFinished()));
-    connect(this, SIGNAL(elementWasRemoved()), m_actualDetector->getRecorder(), SLOT(reloadResultDataFile()));
+    connect(this, SIGNAL(elementWasRemoved()), m_dataManager, SLOT(readResultDataFile()));
     connect(m_actualDetector, SIGNAL(progressValueChanged(int)), this, SLOT(on_progressBar_valueChanged(int)));
     connect(m_actualDetector, SIGNAL(broadcastOutputText(QString)), this, SLOT(update_output_text(QString)));
     connect(this, SIGNAL(updatePixmap(QImage)), this, SLOT(displayPixmap(QImage)));

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -168,6 +168,7 @@ void MainWindow::setSignalsAndSlots(ActualDetector* actualDetector)
     connect(this, SIGNAL(elementWasRemoved()), m_dataManager, SLOT(readResultDataFile()));
     connect(m_actualDetector, SIGNAL(progressValueChanged(int)), this, SLOT(on_progressBar_valueChanged(int)));
     connect(m_actualDetector, SIGNAL(broadcastOutputText(QString)), this, SLOT(update_output_text(QString)));
+    connect(m_dataManager, SIGNAL(messageBroadcasted(QString)), this, SLOT(update_output_text(QString)));
     connect(this, SIGNAL(updatePixmap(QImage)), this, SLOT(displayPixmap(QImage)));
     connect(ui->videoList, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(onVideoListContextMenuRequested(const QPoint&)));
 

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -424,10 +424,12 @@ void MainWindow::on_startButton_clicked()
         ui->progressBar->repaint();
 
         disconnect(this,SIGNAL(updatePixmap(QImage)),this,SLOT(displayPixmap(QImage)));
+
+        m_actualDetector->setNoiseLevel(ui->sliderNoise->value());
+        m_actualDetector->setThresholdLevel(ui->sliderThresh->value());
+
         if(m_actualDetector->start())
         {
-            m_actualDetector->setNoiseLevel(ui->sliderNoise->value());
-            m_actualDetector->setThresholdLevel(ui->sliderThresh->value());
             m_showCameraVideo = false;
             if (threadWebcam)
             {

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -672,7 +672,6 @@ bool MainWindow::checkCamera(const int width, const int height)
         catch( cv::Exception& e )
         {
             qDebug() << "Exception caught: " << QString(e.what());
-            m_camera->stopReadingWebcam();
             ui->outputText->append(tr("ERROR: Found webcam but video frame could not be read. Reconnect and check resolution in settings."));
         }
     }
@@ -846,7 +845,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
         threadWebcam->join();
         threadWebcam.reset();
     }
-    m_camera->stopReadingWebcam();
     m_camera->release();
     QApplication::quit();
 }

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -19,8 +19,8 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
-MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
-    QMainWindow(parent), ui(new Ui::MainWindow), m_camera(cameraPtr)
+MainWindow::MainWindow(Camera* cameraPtr, Config* configPtr, DataManager* dataManager, QWidget* parent) :
+    QMainWindow(parent), ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
     qDebug() << "Constructing MainWindow";
@@ -29,9 +29,11 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     mainWindowCentralWidget->setLayout(ui->mainWindowLayout);
     setCentralWidget(mainWindowCentralWidget);
 
+    m_camera = cameraPtr;
     m_config = configPtr;
+    m_dataManager = dataManager;
 
-    m_programVersion = "0.7.0";
+    m_programVersion = APPLICATION_VERSION;
 
     this->setWindowTitle("UFO Detector | BETA " + m_programVersion);
 
@@ -68,9 +70,7 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     codecInfo->removeSupport(CV_FOURCC('F', 'F', 'V', '1'), VideoCodecSupportInfo::OpenCv);
 #endif
 
-    checkFolders();
-    readLogFileAndGetRootElement();
-    checkDetectionAreaFile();
+    m_dataManager->init();
 
     ui->statusLabel->setStyleSheet(m_detectionStatusStyleOff);
     ui->recordingTestButton->hide();
@@ -83,7 +83,7 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     }
 
     //Add VideoWidget to UI
-    QDomNode node = m_resultDataDomDocument.firstChildElement().firstChild();
+    QDomNode node = m_dataManager->resultDataDomDocument()->firstChildElement().firstChild();
     while( !node.isNull())
     {
         if( node.isElement())
@@ -104,21 +104,13 @@ MainWindow::MainWindow(QWidget *parent, Camera *cameraPtr, Config *configPtr) :
     ui->videoList->scrollToBottom();
 
     //Check for new version
-    if (m_config->checkApplicationUpdates())
-    {
-        m_networkAccessManager = new QNetworkAccessManager();
-        connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(checkForUpdate(QNetworkReply*)) );
-        QNetworkRequest request;
-        request.setUrl(QUrl("http://ufoid.net/version.xml"));
-        request.setRawHeader( "User-Agent" , "Mozilla Firefox" );
-        m_networkAccessManager->get(request);
+    if (m_config->checkApplicationUpdates()) {
+        connect(m_dataManager, SIGNAL(newApplicationVersionAvailable(QString,std::queue<QString>)),
+                this, SLOT(onNewApplicationVersionAvailable(QString,std::queue<QString>)));
+        m_dataManager->checkForUpdates();
     }
-
-
-
     qDebug() << "MainWindow constructed" ;
 }
-
 
 /*
  * Read webcamframe from webcam
@@ -170,7 +162,7 @@ void MainWindow::setSignalsAndSlots(ActualDetector* actualDetector)
     connect(m_actualDetector, SIGNAL(positiveMessage()), this, SLOT(setPositiveMessage()));
     connect(m_actualDetector, SIGNAL(negativeMessage()), this, SLOT(setNegativeMessage()));
     connect(m_actualDetector, SIGNAL(errorReadingDetectionAreaFile()), this, SLOT(setErrorReadingDetectionAreaFile()));
-    connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToVideoList(QString,QString,QString)));
+    connect(m_actualDetector->getRecorder(), SIGNAL(resultDataSaved(QString,QString,QString)), this, SLOT(addVideoToList(QString,QString,QString)));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingStarted()), this, SLOT(onRecordingStarted()));
     connect(m_actualDetector->getRecorder(), SIGNAL(recordingFinished()), this, SLOT(onRecordingFinished()));
     connect(this, SIGNAL(elementWasRemoved()), m_actualDetector->getRecorder(), SLOT(reloadResultDataFile()));
@@ -181,21 +173,21 @@ void MainWindow::setSignalsAndSlots(ActualDetector* actualDetector)
 
     if (m_config->checkAirplanes()){
         m_planeChecker = new PlaneChecker(this,m_config->coordinates());
-        connect(m_planeChecker,SIGNAL(foundNumberOfPlanes(int)),m_actualDetector, SLOT(setAmountOfPlanes(int)));
-        connect(m_actualDetector,SIGNAL(checkPlane()),m_planeChecker, SLOT(callApi()));
+        connect(m_planeChecker, SIGNAL(foundNumberOfPlanes(int)), m_actualDetector, SLOT(setAmountOfPlanes(int)));
+        connect(m_actualDetector, SIGNAL(checkPlane()), m_planeChecker, SLOT(callApi()));
     }
 }
 
 /*
  * Add new VideoWidget element to video list
  */
-void MainWindow::addVideoToVideoList(QString filename, QString datetime, QString videoLength)
+void MainWindow::addVideoToList(QString filename, QString dateTime, QString videoLength)
 {
     bool scroll = false;
-    VideoWidget* newWidget = new VideoWidget(this, filename, datetime, videoLength);
-    connect(newWidget->deleteButton(), SIGNAL(clicked()),this,SLOT(onVideoDeleteClicked()));
-    connect(newWidget->uploadButton(), SIGNAL(clicked()),this,SLOT(onVideoUploadClicked()));
-    connect(newWidget->playButton(), SIGNAL(clicked()),this,SLOT(onVideoPlayClicked()));
+    VideoWidget* newWidget = new VideoWidget(this, filename, dateTime, videoLength);
+    connect(newWidget->deleteButton(), SIGNAL(clicked()), this, SLOT(onVideoDeleteClicked()));
+    connect(newWidget->uploadButton(), SIGNAL(clicked()), this, SLOT(onVideoUploadClicked()));
+    connect(newWidget->playButton(), SIGNAL(clicked()), this, SLOT(onVideoPlayClicked()));
     QListWidgetItem* item = new QListWidgetItem;
     item->setSizeHint(QSize(150,100));
 
@@ -213,7 +205,6 @@ void MainWindow::addVideoToVideoList(QString filename, QString datetime, QString
 
     recordingCounter_++;
     ui->lineCount->setText(QString::number(recordingCounter_));
-    readLogFileAndGetRootElement();
 }
 
 /*
@@ -275,7 +266,7 @@ void MainWindow::onVideoUploadClicked()
         VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
         if(widget->uploadButton()==sender())
         {
-            VideoUploaderDialog* upload = new VideoUploaderDialog(this,widget->videoFileName(),m_config);
+            VideoUploaderDialog* upload = new VideoUploaderDialog(this, widget->videoFileName(), m_config);
             upload->show();
             upload->setAttribute(Qt::WA_DeleteOnClose);
         }
@@ -309,6 +300,24 @@ void MainWindow::onDeleteSelectedVideosClicked()
             QListWidgetItem* item = itemIt.next();
             VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
             this->removeVideo(widget->dateTime());
+        }
+    }
+}
+
+void MainWindow::removeVideo(QString dateTime) {
+    for(int row = 0; row < ui->videoList->count(); row++)
+    {
+        QListWidgetItem *item = ui->videoList->item(row);
+        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
+
+        if(widget->dateTime() == dateTime)
+        {
+            QListWidgetItem *itemToRemove = ui->videoList->takeItem(row);
+            ui->videoList->removeItemWidget(itemToRemove);
+            qDebug() << "Removing" << widget->videoFileName() << "and its thumbnail";
+            QFile::remove(widget->videoFileName());
+            QFile::remove(widget->thumbnailFileName());
+            m_dataManager->removeVideo(dateTime);
         }
     }
 }
@@ -407,7 +416,6 @@ void MainWindow::on_settingsButton_clicked()
     }
 }
 
-
 void MainWindow::on_startButton_clicked()
 {
     if (!m_detecting)
@@ -460,53 +468,6 @@ void MainWindow::on_stopButton_clicked()
     ui->startButton->setText(tr("Start detection"));
 }
 
-void MainWindow::removeVideo(QString dateTime)
-{
-    for(int row = 0; row < ui->videoList->count(); row++)
-    {
-        QListWidgetItem *item = ui->videoList->item(row);
-        VideoWidget* widget = qobject_cast<VideoWidget*>(ui->videoList->itemWidget(item));
-
-        if(widget->dateTime() == dateTime)
-        {
-            QListWidgetItem *itemToRemove = ui->videoList->takeItem(row);
-            ui->videoList->removeItemWidget(itemToRemove);
-            qDebug() << "Removing" << widget->videoFileName() << "and its thumbnail";
-            QFile::remove(widget->videoFileName());
-            QFile::remove(widget->thumbnailFileName());
-        }
-    }
-
-    QDomNode node = m_resultDataDomDocument.firstChildElement().firstChild();
-    while( !node.isNull())
-    {
-        if( node.isElement())
-        {
-            QDomElement element = node.toElement();
-            QString dateInXML = element.attribute("DateTime");
-            if (dateInXML.compare(dateTime)==0)
-            {
-              m_resultDataDomDocument.firstChildElement().removeChild(node);
-              if(!m_resultDataFile.open(QIODevice::WriteOnly | QIODevice::Text))
-              {
-                  qDebug() <<  "Failed to open result data file for item deletion";
-                  return;
-              }
-              else
-              {
-                  QTextStream stream(&m_resultDataFile);
-                  stream.setCodec("UTF-8");
-                  stream << m_resultDataDomDocument.toString();
-                  m_resultDataFile.close();
-              }
-              break;
-            }
-        }
-        node = node.nextSibling();
-    }
-    emit elementWasRemoved();
-}
-
 void MainWindow::on_checkBoxDisplayWebcam_stateChanged(int arg1)
 {
     if (Qt::Unchecked == arg1)
@@ -523,7 +484,6 @@ void MainWindow::on_buttonClear_clicked()
 {
     ui->outputText->clear();
 }
-
 
 void MainWindow::on_recordingTestButton_clicked()
 {
@@ -596,68 +556,6 @@ void MainWindow::adjustCameraViewFrameSize()
     emit cameraViewFrameSizeChanged(cameraFrameSize);
 }
 
-void MainWindow::readLogFileAndGetRootElement()
-{
-    /// @todo refactor result data file & DOM handling to a different class (e.g. ResultData)
-    m_resultDataFile.setFileName(m_config->resultDataFile());
-    if(m_resultDataFile.exists())
-    {
-        if(!m_resultDataFile.open(QIODevice::ReadOnly | QIODevice::Text))
-        {
-            qDebug() << "MainWindow: failed to read the result data file" << m_resultDataFile.fileName();
-        }
-        else
-        {
-            if(!m_resultDataDomDocument.setContent(&m_resultDataFile))
-            {
-                qDebug() << "MainWindow: failed to load the result data file" << m_resultDataFile.fileName();
-            }
-            else
-            {
-                qDebug() << "Correctly loaded root element from result data file";
-            }
-            m_resultDataFile.close();
-        }
-    }
-    else
-    {
-        if(!m_resultDataFile.open(QIODevice::WriteOnly | QIODevice::Text))
-        {
-            qDebug() << "Failed to create result data file" << m_resultDataFile.fileName();
-        }
-        else
-        {
-            qDebug() << "Creating result data file" << m_resultDataFile.fileName();
-            QDomDocument tempFirstTime;
-            tempFirstTime.appendChild(tempFirstTime.createElement("UFOID"));
-            QTextStream stream(&m_resultDataFile);
-            stream << tempFirstTime.toString();
-            m_resultDataFile.close();
-            readLogFileAndGetRootElement();
-        }
-    }
-}
-
-void MainWindow::checkDetectionAreaFile()
-{
-    QString areaFileName = m_config->detectionAreaFile();
-    QFile areaFile(areaFileName);
-    if(areaFile.exists())
-    {
-         qDebug() << "Found detection area file";
-    }
-    else
-    {
-        areaFile.setFileName(areaFileName);
-        if (areaFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            qDebug() << "Created detection area file " << areaFile.fileName();
-            areaFile.close();
-        } else {
-            qDebug() << "Failed to create detection area file " << areaFile.fileName();
-        }
-    }
-}
-
 bool MainWindow::checkCamera(const int width, const int height)
 {
     bool success = false;
@@ -683,122 +581,6 @@ bool MainWindow::checkCamera(const int width, const int height)
     ui->startButton->setEnabled(success);
 
     return success;
-}
-
-void MainWindow::checkFolders()
-{
-    QDir videoFolder(m_config->resultVideoDir());
-    QFileInfo detectionAreaFileInfo(m_config->detectionAreaFile());
-    QFileInfo resultDataFileInfo(m_config->resultDataFile());
-    QFileInfo birdTrainingDataFileInfo(m_config->birdClassifierTrainingFile());
-    QDir detectionAreaFileFolder(detectionAreaFileInfo.absoluteDir());
-    QDir resultDataFileFolder(resultDataFileInfo.absoluteDir());
-    QDir birdTrainingDataFileFolder(birdTrainingDataFileInfo.absoluteDir());
-
-    if (!(videoFolder.exists() && !m_config->resultVideoDir().isEmpty()))
-    {
-        qDebug() << "creating video and image folders";
-        videoFolder.mkpath(m_config->resultImageDir());
-        videoFolder.mkpath(m_config->resultVideoDir());
-    }
-
-    if (!detectionAreaFileFolder.exists() && !detectionAreaFileFolder.absolutePath().isEmpty()) {
-        qDebug() << "Creating folder for detection area file:" << detectionAreaFileFolder.absolutePath();
-        detectionAreaFileFolder.mkpath(detectionAreaFileFolder.absolutePath());
-    }
-
-    if (!resultDataFileFolder.exists() && !resultDataFileFolder.absolutePath().isEmpty()) {
-        qDebug() << "Creating folder for result data file:" << resultDataFileFolder.absolutePath();
-        resultDataFileFolder.mkpath(resultDataFileFolder.absolutePath());
-    }
-
-    if (!birdTrainingDataFileFolder.exists() && !birdTrainingDataFileFolder.absolutePath().isEmpty()) {
-        qDebug() << "Creating folder for bird classifier training data file:" << birdTrainingDataFileFolder.absolutePath();
-        birdTrainingDataFileFolder.mkpath(birdTrainingDataFileFolder.absolutePath());
-    }
-}
-
-/*
- * Check if xml indicates that there is a new version of the program. Validate userToken if necessary
- */
-void MainWindow::checkForUpdate(QNetworkReply *reply)
-{
-    QByteArray data = reply->readAll();
-    qDebug() <<   "Downloaded version data," << data.size() << "bytes";
-    QDomDocument versionXML;
-
-    if(!versionXML.setContent(data))
-    {
-        qWarning() << "Failed to parse downloaded version data";
-    }
-    else
-    {
-        QDomElement root;
-        root=versionXML.firstChildElement();
-        QString currentVersion;
-        int currentClassifierVersion = 1;
-        std::queue<QString> messageInXML;
-
-        QDomNode node = root.firstChild();
-        while( !node.isNull())
-        {
-            if( node.isElement())
-            {
-                if(node.nodeName()=="version")
-                {
-                    QDomElement element = node.toElement();
-                    currentVersion=element.text();
-                }
-                if(node.nodeName()=="classifier")
-                {
-                    QDomElement element = node.toElement();
-                    currentClassifierVersion=element.text().toInt();
-                }
-                if(node.nodeName()=="message")
-                {
-                    QDomElement element = node.toElement();
-                    messageInXML.push(element.text());
-                }
-            }
-            node = node.nextSibling();
-        }
-
-        if(currentVersion>m_programVersion)
-        {
-            m_updateApplicationDialog = new UpdateApplicationDialog(this, currentVersion, messageInXML);
-            m_updateApplicationDialog->show();
-            m_updateApplicationDialog->setAttribute(Qt::WA_DeleteOnClose);
-        }
-        else if (currentClassifierVersion>m_config->classifierVersion()){
-            disconnect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(checkForUpdate(QNetworkReply*)) );
-            connect(m_networkAccessManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloadClassifier(QNetworkReply*)) );
-            QNetworkRequest request;
-            request.setUrl(QUrl("http://ufoid.net/cascade.xml"));
-            request.setRawHeader( "User-Agent" , "Mozilla Firefox" );
-            m_networkAccessManager->get(request);
-        }
-    }
-
-    delete reply;
-    reply = nullptr;
-
-}
-
-void MainWindow::downloadClassifier(QNetworkReply *reply)
-{
-    if(reply->error() == QNetworkReply::NoError)
-    {
-        QByteArray data = reply->readAll();
-        qDebug() <<  "Downloaded classifier data," << data.size() << "bytes";
-        QFile file(m_config->birdClassifierTrainingFile());
-        file.open(QIODevice::WriteOnly);
-        file.write(data);
-        file.close();
-        m_config->setClassifierVersion(m_config->classifierVersion()+1);
-        qDebug() <<  "Updated bird classifier file";
-    }
-    delete reply;
-    reply = nullptr;
 }
 
 void MainWindow::onRecordingStarted()
@@ -867,5 +649,11 @@ void MainWindow::on_toolButtonNoise_clicked()
 void MainWindow::on_toolButtonThresh_clicked()
 {
     QMessageBox::information(this, tr("Information"), tr("Select the threshold filter value that will be used in the motion detection algorithm. \nIncrease the value if clouds are being detected. \nRecommended value: 10"));
+}
+
+void MainWindow::onNewApplicationVersionAvailable(QString newVersion, std::queue<QString> messageInXml) {
+    m_updateApplicationDialog = new UpdateApplicationDialog(this, newVersion, messageInXml);
+    m_updateApplicationDialog->show();
+    m_updateApplicationDialog->setAttribute(Qt::WA_DeleteOnClose);
 }
 

--- a/ui-qt/mainwindow.cpp
+++ b/ui-qt/mainwindow.cpp
@@ -406,7 +406,7 @@ void MainWindow::on_settingsButton_clicked()
 {
     if (!m_detecting)
     {
-        m_settingsDialog = new SettingsDialog(0, m_camera, m_config);
+        m_settingsDialog = new SettingsDialog(0, m_camera, m_config, m_dataManager);
         m_settingsDialog->setModal(true);
         m_settingsDialog->show();
         m_settingsDialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/ui-qt/polygonedge.cpp
+++ b/ui-qt/polygonedge.cpp
@@ -1,0 +1,51 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "polygonedge.h"
+
+PolygonEdge::PolygonEdge(PolygonNode* startNode, PolygonNode* endNode,
+    QGraphicsLineItem* parent) : QGraphicsLineItem(parent)
+{
+    setPen(QPen(Qt::red));
+
+    if (startNode && endNode) {
+        m_startNode = startNode;
+        m_endNode = endNode;
+        m_startNode->addEdge(this);
+        m_endNode->addEdge(this);
+        setLine(m_startNode->x(), m_startNode->y(), m_endNode->x(), m_endNode->y());
+    } else {
+        m_startNode = NULL;
+        m_endNode = NULL;
+    }
+}
+
+PolygonEdge::~PolygonEdge() {
+    m_startNode = NULL;
+    m_endNode = NULL;
+}
+
+void PolygonEdge::notifyNodeChange() {
+    if (m_startNode && m_endNode) {
+        setLine(m_startNode->x(), m_startNode->y(), m_endNode->x(), m_endNode->y());
+    }
+}
+
+int PolygonEdge::type() const {
+    return PolygonEdge::Type;
+}

--- a/ui-qt/polygonedge.h
+++ b/ui-qt/polygonedge.h
@@ -1,0 +1,50 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef POLYGONEDGE_H
+#define POLYGONEDGE_H
+
+#include "polygonnode.h"
+#include <QObject>
+#include <QGraphicsLineItem>
+
+class PolygonEdge : public QGraphicsLineItem
+{
+public:
+
+    enum { Type = QGraphicsItem::UserType + 2 };
+
+    PolygonEdge(PolygonNode* startNode, PolygonNode* endNode, QGraphicsLineItem* parent = 0);
+    ~PolygonEdge();
+
+    /**
+     * @brief Notify this class about node change.
+     */
+    void notifyNodeChange();
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+    PolygonNode* m_startNode;
+    PolygonNode* m_endNode;
+
+protected:
+    int type() const override;
+};
+
+#endif // POLYGONEDGE_H

--- a/ui-qt/polygonnode.cpp
+++ b/ui-qt/polygonnode.cpp
@@ -1,0 +1,54 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "polygonnode.h"
+#include "polygonedge.h"
+
+PolygonNode::PolygonNode(QGraphicsItem* parent) : QGraphicsEllipseItem(parent)
+{
+    setFlag(GraphicsItemFlag::ItemIsSelectable);
+    setFlag(GraphicsItemFlag::ItemIsMovable);
+    setFlag(GraphicsItemFlag::ItemSendsGeometryChanges);
+    int radius = 4;
+    setRect(-radius, -radius, radius*2, radius*2);
+    setPen(QPen(Qt::gray));
+    setBrush(QBrush(Qt::black));
+}
+
+PolygonNode::~PolygonNode() {
+    m_connectedEdges.clear();
+}
+
+void PolygonNode::addEdge(PolygonEdge* edge) {
+    if (edge) {
+        m_connectedEdges.append(edge);
+    }
+}
+
+int PolygonNode::type() const {
+    return PolygonNode::Type;
+}
+
+QVariant PolygonNode::itemChange(GraphicsItemChange change, const QVariant &value) {
+    if (QGraphicsItem::ItemPositionHasChanged == change) {
+        foreach (PolygonEdge* edge, m_connectedEdges) {
+            edge->notifyNodeChange();
+        }
+    }
+    return QGraphicsItem::itemChange(change, value);
+}

--- a/ui-qt/polygonnode.h
+++ b/ui-qt/polygonnode.h
@@ -1,0 +1,56 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef POLYGONNODE_H
+#define POLYGONNODE_H
+
+#include <QObject>
+#include <QGraphicsEllipseItem>
+#include <QPen>
+#include <QBrush>
+#include <QDebug>
+
+class PolygonEdge;
+
+
+class PolygonNode : public QGraphicsEllipseItem
+{
+public:
+
+    enum { Type = QGraphicsItem::UserType + 1 };
+
+    PolygonNode(QGraphicsItem *parent = 0);
+    ~PolygonNode();
+
+    /**
+     * @brief Add an edge which is connected to this node.
+     * @param edge
+     */
+    void addEdge(PolygonEdge* edge);
+
+#ifndef _UNIT_TEST_
+private:
+#endif
+    QVector<PolygonEdge*> m_connectedEdges;  ///< edges connected to this node
+
+protected:
+    int type() const override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+};
+
+#endif // POLYGONNODE_H

--- a/ui-qt/settingsdialog.cpp
+++ b/ui-qt/settingsdialog.cpp
@@ -25,11 +25,6 @@
 #include <QDebug>
 #include <QDomDocument>
 
-
-/* Note:
- * Checking the status of the area file is broken. Commented out
- */
-
 SettingsDialog::SettingsDialog(QWidget* parent, Camera* camera, Config* config,
     DataManager* dataManager) :
     QDialog(parent), ui(new Ui::SettingsDialog), m_camera(camera), m_config(config),
@@ -78,10 +73,7 @@ SettingsDialog::SettingsDialog(QWidget* parent, Camera* camera, Config* config,
     setWindowFlags(Qt::FramelessWindowHint);
     setWindowFlags(Qt::WindowTitleHint);
     m_detectionAreaDialogIsOpen=false;
-    wasSaved=false;
-
-//    connect(this,SIGNAL(finishedCheckingXML()),this,SLOT(cleanupThreadCheckXML()));
-//    threadXMLfile.reset(new std::thread(&Settings::checkAreaFile, this));
+    m_wasSaved=false;
 }
 
 void SettingsDialog::saveSettings()
@@ -102,27 +94,6 @@ void SettingsDialog::saveSettings()
 
 }
 
-//void Settings::checkAreaFile()
-//{
-//    QFile fileXML(xmlFile);
-//    QDomDocument doc;
-
-//    if(!fileXML.open(QIODevice::ReadOnly | QIODevice::Text))
-//	{
-//        qDebug() << "fail reading the area file";
-//    }
-//    else
-//	{
-//        if(!doc.setContent(&fileXML))
-//		{
-//            ui->lineStatus->setText(tr("File found but is empty. Select area of detection."));
-//        }
-//        else ui->lineStatus->setText(tr("File found and loaded correctly"));
-//    }
-	
-//    emit finishedCheckingXML();
-//}
-
 void SettingsDialog::on_toolButtonVideoPath_clicked()
 {
     QString videoFilePath=QFileDialog::getExistingDirectory(this,tr("Select Directory"),QDir::currentPath(),QFileDialog::ShowDirsOnly);
@@ -134,8 +105,6 @@ void SettingsDialog::on_toolButtonVideoPath_clicked()
 
 SettingsDialog::~SettingsDialog()
 {
-    qDebug() << "destructor settings";
-    //disconnect(this,SIGNAL(finishedCheckingXML()),this,SLOT(cleanupThreadCheckXML()));
     delete ui;
 }
 
@@ -159,7 +128,7 @@ void SettingsDialog::on_buttonSave_clicked()
         }
     }
     saveSettings();
-    wasSaved=true;
+    m_wasSaved = true;
     /// @todo apply settings on-the-fly
     QMessageBox::information(this, tr("Information"), tr("Settings saved successfully. Restart the application to apply the changes."));
 }
@@ -172,17 +141,6 @@ void SettingsDialog::on_buttonCancel_clicked()
         delete m_detectionAreaDialog;
     }
     this->close();
-//    if(!threadXMLfile)
-//	{
-//        if(dialogIsOpened)
-//		{
-//            disconnect(myDialog,SIGNAL(savedFile()),this,SLOT(startThreadCheckXML()));
-//            myDialog->close();
-//            delete myDialog;
-//        }
-//        this->close();
-//    }
-//    else QMessageBox::information(this, tr("Information"), tr("Please wait until checking of the area file has finished"));
 }
 
 void SettingsDialog::on_checkBoxsaveImages_stateChanged(int arg1)
@@ -224,7 +182,7 @@ void SettingsDialog::on_toolButtonImagePath_clicked()
 
 void SettingsDialog::on_buttonSelectDetectionArea_clicked()
 {
-    if (wasSaved)
+    if (m_wasSaved)
 	{
         QMessageBox::warning(this, tr("Warning"), tr("Restart the application before creating detection area file"));
     }
@@ -234,7 +192,6 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
         m_detectionAreaDialog = new DetectionAreaEditDialog(0, m_camera, m_config, m_dataManager);
         m_detectionAreaDialog->setModal(true);
         m_detectionAreaDialog->show();
-        //connect(myDialog,SIGNAL(savedFile()),this,SLOT(startThreadCheckXML()));
     }
 }
 
@@ -250,22 +207,6 @@ void SettingsDialog::onResolutionAcceptedInDialog(QSize resolution)
     ui->lineEditCameraWidth->setText(QString::number(resolution.width()));
     ui->lineEditCameraHeight->setText(QString::number(resolution.height()));
 }
-
-//void Settings::startThreadCheckXML()
-//{
-//    ui->lineStatus->setText(tr("Checking..."));
-//    threadXMLfile.reset(new std::thread(&Settings::checkAreaFile, this));
-//}
-
-//void Settings::cleanupThreadCheckXML()
-//{
-//    if(threadXMLfile)
-//	{
-//        threadXMLfile->join();
-//        threadXMLfile.reset();
-//        qDebug() << "cleanup done";
-//    }
-//}
 
 void SettingsDialog::on_toolButtonCodecHelp_clicked()
 {

--- a/ui-qt/settingsdialog.cpp
+++ b/ui-qt/settingsdialog.cpp
@@ -30,8 +30,10 @@
  * Checking the status of the area file is broken. Commented out
  */
 
-SettingsDialog::SettingsDialog(QWidget *parent, Camera *camPtr, Config *configPtr) :
-    QDialog(parent), ui(new Ui::SettingsDialog), cameraPtr(camPtr), m_config(configPtr)
+SettingsDialog::SettingsDialog(QWidget* parent, Camera* camera, Config* config,
+    DataManager* dataManager) :
+    QDialog(parent), ui(new Ui::SettingsDialog), m_camera(camera), m_config(config),
+    m_dataManager(dataManager)
 {
     ui->setupUi(this);
 
@@ -144,7 +146,7 @@ void SettingsDialog::on_buttonSave_clicked()
     int cameraWidth = ui->lineEditCameraWidth->text().toInt();
     int cameraHeight = ui->lineEditCameraHeight->text().toInt();
     int cameraAspectRatio =  (double)cameraWidth / (double)cameraHeight * 10000;
-    if (!cameraPtr->knownAspectRatios().contains(cameraAspectRatio))
+    if (!m_camera->knownAspectRatios().contains(cameraAspectRatio))
     {
         QMessageBox::warning(this, tr("Error"), tr("Unknown camera aspect ratio. Please change camera width and/or height. Settings are not saved."));
         return;
@@ -229,7 +231,7 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
     else
 	{
         m_detectionAreaDialogIsOpen=true;
-        m_detectionAreaDialog = new DetectionAreaEditDialog(0, cameraPtr, m_config);
+        m_detectionAreaDialog = new DetectionAreaEditDialog(0, m_camera, m_config, m_dataManager);
         m_detectionAreaDialog->setModal(true);
         m_detectionAreaDialog->show();
         //connect(myDialog,SIGNAL(savedFile()),this,SLOT(startThreadCheckXML()));
@@ -238,7 +240,7 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
 
 void SettingsDialog::on_toolButtonResolutionDialog_clicked()
 {
-    m_resolutionDialog = new CameraResolutionDialog(cameraPtr, m_config, this);
+    m_resolutionDialog = new CameraResolutionDialog(m_camera, m_config, this);
     connect(m_resolutionDialog, SIGNAL(resolutionAccepted(QSize)), this, SLOT(onResolutionAcceptedInDialog(QSize)));
     m_resolutionDialog->show();
 }

--- a/ui-qt/settingsdialog.cpp
+++ b/ui-qt/settingsdialog.cpp
@@ -187,7 +187,7 @@ void SettingsDialog::on_buttonSelectDetectionArea_clicked()
         QMessageBox::warning(this, tr("Warning"), tr("Restart the application before creating detection area file"));
     }
     else
-	{
+    {
         m_detectionAreaDialogIsOpen=true;
         m_detectionAreaDialog = new DetectionAreaEditDialog(0, m_camera, m_config, m_dataManager);
         m_detectionAreaDialog->setModal(true);

--- a/ui-qt/settingsdialog.h
+++ b/ui-qt/settingsdialog.h
@@ -43,13 +43,15 @@ class SettingsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SettingsDialog(QWidget *parent = 0, Camera* camPtr = 0, Config* configPtr = 0);
+    explicit SettingsDialog(QWidget* parent = 0, Camera* camera = 0, Config* config = 0,
+        DataManager* dataManager = 0);
     ~SettingsDialog();
 
 private:
     Ui::SettingsDialog *ui;
-    Camera* cameraPtr;
+    Camera* m_camera;
     Config* m_config;
+    DataManager* m_dataManager;
     void saveSettings();
     bool m_detectionAreaDialogIsOpen;
     bool wasSaved;

--- a/ui-qt/settingsdialog.h
+++ b/ui-qt/settingsdialog.h
@@ -52,15 +52,12 @@ private:
     Camera* m_camera;
     Config* m_config;
     DataManager* m_dataManager;
-    void saveSettings();
     bool m_detectionAreaDialogIsOpen;
-    bool wasSaved;
+    bool m_wasSaved;
     DetectionAreaEditDialog* m_detectionAreaDialog;
     CameraResolutionDialog* m_resolutionDialog;
 
-    //std::unique_ptr<std::thread> threadXMLfile;
-    //void checkAreaFile();
-
+    void saveSettings();
 
 private slots:
     void on_toolButtonVideoPath_clicked();
@@ -72,21 +69,12 @@ private slots:
     void on_buttonSelectDetectionArea_clicked();
     void on_toolButtonResolutionDialog_clicked();
     void onResolutionAcceptedInDialog(QSize resolution);
-    //void startThreadCheckXML();
-    //void cleanupThreadCheckXML();
     void on_toolButtonCodecHelp_clicked();
     void on_toolButtonTokenHelp_clicked();
 
     void on_checkBoxFilterAiplanes_clicked();
 
     void on_toolButtonFilterAirplanes_clicked();
-
-public slots:
-
-signals:
-    //void finishedCheckingXML();
-
-
 };
 
 #endif // SETTINGS_H

--- a/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
+++ b/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
@@ -23,7 +23,9 @@ SOURCES += ./main.cpp\
     ../../detectionareaeditdialog.cpp \
     ../../../ufo-detector-engine/camera.cpp \
     ../../../ufo-detector-engine/camerainfo.cpp \
-    ../../../ufo-detector-engine/videocodecsupportinfo.cpp
+    ../../../ufo-detector-engine/videocodecsupportinfo.cpp \
+    ../../polygonnode.cpp \
+    ../../polygonedge.cpp
 
 HEADERS  += ./mainwindow.h \
     ../../../ufo-detector-engine/config.h \
@@ -31,7 +33,9 @@ HEADERS  += ./mainwindow.h \
     ../../detectionareaeditdialog.h \
     ../../../ufo-detector-engine/camera.h \
     ../../../ufo-detector-engine/camerainfo.h \
-    ../../../ufo-detector-engine/videocodecsupportinfo.h
+    ../../../ufo-detector-engine/videocodecsupportinfo.h \
+    ../../polygonnode.h \
+    ../../polygonedge.h
 
 FORMS    += mainwindow.ui \
     ../../detectionareaeditdialog.ui

--- a/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
+++ b/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui xml
+QT       += core gui xml network
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -19,6 +19,7 @@ include(../../../ufo-detector-engine/opencv.pri)
 SOURCES += ./main.cpp\
     ./mainwindow.cpp \
     ../../../ufo-detector-engine/config.cpp \
+    ../../../ufo-detector-engine/datamanager.cpp \
     ../../graphicsscene.cpp \
     ../../detectionareaeditdialog.cpp \
     ../../../ufo-detector-engine/camera.cpp \
@@ -29,6 +30,7 @@ SOURCES += ./main.cpp\
 
 HEADERS  += ./mainwindow.h \
     ../../../ufo-detector-engine/config.h \
+    ../../../ufo-detector-engine/datamanager.h \
     ../../graphicsscene.h \
     ../../detectionareaeditdialog.h \
     ../../../ufo-detector-engine/camera.h \

--- a/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
+++ b/ui-qt/test/detectionareaeditor-dev/detectionareaeditor-dev.pro
@@ -1,0 +1,37 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2017-04-12T10:34:03
+#
+#-------------------------------------------------
+
+QT       += core gui xml
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+TARGET = detectionareaeditor-dev
+TEMPLATE = app
+
+INCLUDEPATH += ../.. \
+    ../../../ufo-detector-engine
+
+include(../../../ufo-detector-engine/opencv.pri)
+
+SOURCES += ./main.cpp\
+    ./mainwindow.cpp \
+    ../../../ufo-detector-engine/config.cpp \
+    ../../graphicsscene.cpp \
+    ../../detectionareaeditdialog.cpp \
+    ../../../ufo-detector-engine/camera.cpp \
+    ../../../ufo-detector-engine/camerainfo.cpp \
+    ../../../ufo-detector-engine/videocodecsupportinfo.cpp
+
+HEADERS  += ./mainwindow.h \
+    ../../../ufo-detector-engine/config.h \
+    ../../graphicsscene.h \
+    ../../detectionareaeditdialog.h \
+    ../../../ufo-detector-engine/camera.h \
+    ../../../ufo-detector-engine/camerainfo.h \
+    ../../../ufo-detector-engine/videocodecsupportinfo.h
+
+FORMS    += mainwindow.ui \
+    ../../detectionareaeditdialog.ui

--- a/ui-qt/test/detectionareaeditor-dev/main.cpp
+++ b/ui-qt/test/detectionareaeditor-dev/main.cpp
@@ -1,0 +1,29 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mainwindow.h"
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+    MainWindow w;
+    w.show();
+
+    return a.exec();
+}

--- a/ui-qt/test/detectionareaeditor-dev/mainwindow.cpp
+++ b/ui-qt/test/detectionareaeditor-dev/mainwindow.cpp
@@ -27,7 +27,9 @@ MainWindow::MainWindow(QWidget *parent) :
     m_config = new Config();
     m_camera = new Camera(m_config->cameraIndex(), m_config->cameraWidth(), m_config->cameraHeight());
     m_camera->init();
-    m_editor = new DetectionAreaEditDialog(this, m_camera, m_config);
+    m_dataManager = new DataManager(m_config);
+    m_dataManager->init();
+    m_editor = new DetectionAreaEditDialog(this, m_camera, m_config, m_dataManager);
     qDebug() << "Application dir path:" << QApplication::applicationDirPath();
     on_openDetectionAreaEditorButton_clicked();
 }

--- a/ui-qt/test/detectionareaeditor-dev/mainwindow.cpp
+++ b/ui-qt/test/detectionareaeditor-dev/mainwindow.cpp
@@ -1,0 +1,48 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mainwindow.h"
+#include "ui_mainwindow.h"
+
+MainWindow::MainWindow(QWidget *parent) :
+    QMainWindow(parent),
+    ui(new Ui::MainWindow)
+{
+    ui->setupUi(this);
+    m_config = new Config();
+    m_camera = new Camera(m_config->cameraIndex(), m_config->cameraWidth(), m_config->cameraHeight());
+    m_camera->init();
+    m_editor = new DetectionAreaEditDialog(this, m_camera, m_config);
+    qDebug() << "Application dir path:" << QApplication::applicationDirPath();
+    on_openDetectionAreaEditorButton_clicked();
+}
+
+MainWindow::~MainWindow() {
+    delete ui;
+    m_camera->deleteLater();
+    m_config->deleteLater();
+    m_editor->deleteLater();
+}
+
+void MainWindow::on_openDetectionAreaEditorButton_clicked() {
+    if (!m_editor->isVisible()) {
+        m_editor->setModal(true);
+        m_editor->setAttribute(Qt::WA_AlwaysStackOnTop);
+        m_editor->show();
+    }
+}

--- a/ui-qt/test/detectionareaeditor-dev/mainwindow.h
+++ b/ui-qt/test/detectionareaeditor-dev/mainwindow.h
@@ -21,6 +21,7 @@
 
 #include "camera.h"
 #include "config.h"
+#include "datamanager.h"
 #include "detectionareaeditdialog.h"
 #include <QMainWindow>
 #include <QApplication>
@@ -41,6 +42,7 @@ private:
     Ui::MainWindow *ui;
     Config* m_config;
     Camera* m_camera;
+    DataManager* m_dataManager;
     DetectionAreaEditDialog* m_editor;
 
 private slots:

--- a/ui-qt/test/detectionareaeditor-dev/mainwindow.h
+++ b/ui-qt/test/detectionareaeditor-dev/mainwindow.h
@@ -1,0 +1,51 @@
+/*
+ * UFO Detector | www.UFOID.net
+ *
+ * Copyright (C) 2016 UFOID
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include "camera.h"
+#include "config.h"
+#include "detectionareaeditdialog.h"
+#include <QMainWindow>
+#include <QApplication>
+
+namespace Ui {
+class MainWindow;
+}
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = 0);
+    ~MainWindow();
+
+private:
+    Ui::MainWindow *ui;
+    Config* m_config;
+    Camera* m_camera;
+    DetectionAreaEditDialog* m_editor;
+
+private slots:
+    void on_openDetectionAreaEditorButton_clicked();
+
+};
+
+#endif // MAINWINDOW_H

--- a/ui-qt/test/detectionareaeditor-dev/mainwindow.ui
+++ b/ui-qt/test/detectionareaeditor-dev/mainwindow.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QPushButton" name="openDetectionAreaEditorButton">
+      <property name="text">
+       <string>Open detection area editor</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>400</width>
+     <height>27</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menu_File">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="action_Quit"/>
+   </widget>
+   <addaction name="menu_File"/>
+  </widget>
+  <widget class="QStatusBar" name="statusBar"/>
+  <action name="action_Quit">
+   <property name="text">
+    <string>&amp;Quit</string>
+   </property>
+  </action>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- Fixes UFOID/UFO-Detector#46
- Detection area file is now in polygon format which means it is easy to edit manually in CLI usage. It's also up to 100 times faster than the point file. ActualDetector is using the same type of point vector for detection area as before so nothing else changed in that regard but the file format.
- Added possibility to edit detection area in the editor dialog. Existing area is shown first.
- CLI version has an option to reset the detection area file (~~--reset-detfile~~ --reset-area-file) in order to have a skeleton file for editing.

The new file format looks like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<detectionarealist>
  <detectionarea>
    <camera id="0" width="352" height="288"/>
    <polygon>
      <point x="0" y="0"/>
      <point x="0" y="287"/>
      <point x="351" y="287"/>
      <point x="351" y="0"/>
    </polygon>
  </detectionarea>
</detectionarealist>

```

The format makes it possible to have multiple cameras and have a detection area defined for each of them. Also, it's possible to have multiple polygons in a detection area. However, these are not implemented in the code so far.

BTW: Mark, did you compare which one is faster/handier, to use the current point vector detection area, or to define it as a mask image?

It seems this pull request is including everything from the point my master branch forks from your master branch... Hope I'm not screwing anything here. :)

